### PR TITLE
Also whitelisting introspect

### DIFF
--- a/src/middleware/login.ts
+++ b/src/middleware/login.ts
@@ -8,6 +8,7 @@ const whitelistPath = [
   '/authorize',
   '/reset-password',
   '/token',
+  '/introspect',
   '/validate-bearer',
   '/validate-totp',
 ];


### PR DESCRIPTION
We're whitelisting the 'introspect' endpoint (for now).

This is low risk because tokens should not be guessable, but eventually we might want to force authentication on this again.
