### PR TITLE
Create-User CSS Fix

### DIFF
--- a/assets/form.css
+++ b/assets/form.css
@@ -170,7 +170,7 @@ input.totp {
 }
 
 .active input {
-  margin: 0 0 0px 5px;
+  margin: 0 5px 0 0;
 }
 
 form p {

--- a/assets/form.css
+++ b/assets/form.css
@@ -165,11 +165,14 @@ input.totp {
   font-family: monospace;
 }
 
-.active {
+.checkbox {
   flex-direction: row;
 }
 
-.active input {
+.checkbox :nth-child(1) { order: 2; }
+.checkbox :nth-child(2) { order: 1; }
+
+.checkbox input {
   margin: 0 5px 0 0;
 }
 

--- a/assets/form.css
+++ b/assets/form.css
@@ -44,11 +44,13 @@ form label {
 }
 
 form label:not(:last-child) {
-  margin-bottom: 1em;
+  margin-bottom: 3em;
 }
 
-form input,
-form button {
+form input:not([type='checkbox']):not([type='radio']),
+form button,
+form select {
+  min-height: 3em;
   line-height: 3;
   padding: 0;
   border-radius: .25ex;
@@ -65,10 +67,6 @@ form select {
   margin-top: 1ex;
 }
 
-form select {
-  height: 56px;
-}
-
 form input:hover {
   border-color: #8c8c8c;
 }
@@ -78,18 +76,48 @@ form input:focus {
   border-color: #1E88E5;
 }
 
-
-form input:invalid,
-form select {
+form input:invalid {
   box-shadow: none;
   outline: none;
   outline-color: transparent;
+  border-color: transparent;
+}
+
+form input:invalid:focus {
   border-color: #F44336;
 }
 
-form input:invalid:focus,
+form input[type=checkbox],
+form input[type=radio] {
+  -moz-appearance: none;
+  -webkit-appearance: none;
+  width: 2ex;
+  height: 2ex;
+  cursor: pointer;
+  border: 2px solid
+  #ccc;
+}
+
+form input[type=checkbox]:checked,
+form input[type=radio]:checked {
+  background:#1e88e5;
+  border-color:#1e88e5 !important;
+  box-shadow: inset 0 0 0 3px white;
+}
+
+form input[type=checkbox]:focus,
+form input[type=radio]:focus {
+  border-color: #1e88e5
+}
+
+
+form input[type=checkbox]:hover:not(:focus),
+form input[type=radio]:hover:not(:focus) {
+  border-color: #8c8c8c;
+}
+
 form select:focus {
-  border-color: #EF9A9A;
+  border-color: #1e88e5;
 }
 
 :focus {outline:none;}
@@ -105,6 +133,12 @@ form button {
 
 form button:hover {
   transform: translateY(-2px) scale(1.02);
+}
+
+form:invalid button[type=submit] {
+  background-color: #CCC;
+  transform: none;
+  pointer-events: none;
 }
 
 .msg.info {
@@ -173,7 +207,11 @@ input.totp {
 .checkbox :nth-child(2) { order: 1; }
 
 .checkbox input {
-  margin: 0 5px 0 0;
+  margin: 0 1ex 0 0;
+}
+
+.checkbox span {
+  cursor: pointer;
 }
 
 form p {

--- a/assets/form.css
+++ b/assets/form.css
@@ -54,7 +54,8 @@ form button {
   border-radius: .25ex;
 }
 
-form input {
+form input,
+form select {
   background: rgba(0,0,0,.04);
   border-width: 0 0 2px 0;
   border-style: solid;
@@ -62,6 +63,10 @@ form input {
   text-indent: 1ex;
   transition: border-color .5s cubic-bezier(0.075, 0.82, 0.165, 1);
   margin-top: 1ex;
+}
+
+form select {
+  height: 56px;
 }
 
 form input:hover {
@@ -74,14 +79,16 @@ form input:focus {
 }
 
 
-form input:invalid {
+form input:invalid,
+form select {
   box-shadow: none;
   outline: none;
   outline-color: transparent;
   border-color: #F44336;
 }
 
-form input:invalid:focus {
+form input:invalid:focus,
+form select:focus {
   border-color: #EF9A9A;
 }
 
@@ -156,6 +163,14 @@ form button:hover {
 
 input.totp {
   font-family: monospace;
+}
+
+.active {
+  flex-direction: row;
+}
+
+.active input {
+  margin: 0 0 0px 5px;
 }
 
 form p {

--- a/assets/form.css
+++ b/assets/form.css
@@ -94,8 +94,15 @@ form input[type=radio] {
   width: 2ex;
   height: 2ex;
   cursor: pointer;
-  border: 2px solid
-  #ccc;
+  border: 2px solid #ccc;
+}
+
+form input[type=checkbox] {
+  border-radius: .2ex;
+}
+
+form input[type=radio] {
+  border-radius: 50%;
 }
 
 form input[type=checkbox]:checked,

--- a/templates/create-user.hbs
+++ b/templates/create-user.hbs
@@ -28,8 +28,8 @@
     </label>
 
     <label for="active" class="active">
-      <span>Make user active</span>
       <input type="checkbox" name="active" value="1">
+      <span>Make user active</span>
     </label>
   </fieldset>
 

--- a/templates/create-user.hbs
+++ b/templates/create-user.hbs
@@ -27,15 +27,15 @@
       </select>
     </label>
 
-    <label for="active" class="active">
-      <input type="checkbox" name="active" value="1">
+    <label for="active" class="checkbox">
       <span>Make user active</span>
+      <input type="checkbox" name="active" value="1">
     </label>
   </fieldset>
 
   <fieldset>
     <label>
-      <button type="submit">Create User</button>
+      <button type="submit">Create New User</button>
     </label>
   </fieldset>
 

--- a/templates/create-user.hbs
+++ b/templates/create-user.hbs
@@ -27,7 +27,7 @@
       </select>
     </label>
 
-    <label for="active">
+    <label for="active" class="active">
       <span>Make user active</span>
       <input type="checkbox" name="active" value="1">
     </label>

--- a/templates/create-user.hbs
+++ b/templates/create-user.hbs
@@ -27,9 +27,9 @@
       </select>
     </label>
 
-    <label for="active" class="checkbox">
-      <span>Make user active</span>
-      <input type="checkbox" name="active" value="1">
+    <label for="activate" class="checkbox">
+      <span>Activate user account immediately</span>
+      <input type="checkbox" id="activate" value="1">
     </label>
   </fieldset>
 


### PR DESCRIPTION
#119 
When an existing user is creating a new user, the existing user can actually pick user type & user active, it needed select/option & checkbox. This PR is CSS edit for that.
![Screenshot from 2019-12-11 13-36-43](https://user-images.githubusercontent.com/28197089/70650428-13cc3200-1c1d-11ea-8da4-79cc816ca270.png)
