### PR TITLE
Make sure 'publicUrl' is set.

### DIFF
--- a/src/main-mw.ts
+++ b/src/main-mw.ts
@@ -8,6 +8,10 @@ import routes from './routes';
 
 export default function(): Middleware {
 
+  if (process.env.PUBLIC_URI === undefined) {
+    throw new Error('A PUBLIC_URI environment variable');
+  }
+
   const middlewares = [
     halBrowser({
       title: 'a12n-server',


### PR DESCRIPTION
An extra line of defense in case a12n-server is used just as a 'middleware', not the full server.