### PR TITLE
Fix csv parsing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -963,6 +963,11 @@
       "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-4.8.3.tgz",
       "integrity": "sha512-0GPxubzYzSn08lhNTWDCkcDKn8krmw0WuscqB2RrW6sugGGskbwaaEz7PCFFwbQ0phNGTTieiyfzzu3S/jZZ7Q=="
     },
+    "csv-stringify": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-5.5.0.tgz",
+      "integrity": "sha512-G05575DSO/9vFzQxZN+Srh30cNyHk0SM0ePyiTChMD5WVt7GMTVPBQf4rtgMF6mqhNCJUPw4pN8LDe8MF9EYOA=="
+    },
     "debug": {
       "version": "3.2.6",
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "@curveball/router": "^0.2.4",
     "@curveball/session": "^0.5.0",
     "bcrypt": "^4.0.1",
+    "csv-stringify": "^5.5.0",
     "hal-browser": "^0.8.6",
     "handlebars": "^4.7.6",
     "mysql2": "^2.1.0",

--- a/src/log/formats/csv.ts
+++ b/src/log/formats/csv.ts
@@ -1,17 +1,21 @@
 import { eventTypeString, LogEntry } from '../types';
 
+import stringify from 'csv-stringify/lib/sync';
+
 export default function csv(log: LogEntry[]): string {
 
-  const header = 'time,eventType,ip,userAgent\n';
-  return header + log.map( entry => {
-
-    return [
-      entry.time.toISOString(),
-      eventTypeString.get(entry.eventType),
-      entry.ip,
-      `"${entry.userAgent}"`
-    ];
-
-  }).join('\n');
+  return stringify(log, {
+    header: true,
+    columns: {
+      time: 'time',
+      eventType: 'eventType',
+      ip: 'ip',
+      userAgent: 'userAgent',
+    },
+    cast: {
+      date: (value) => value.toISOString(),
+      number: (value) => eventTypeString.get(value),
+    }
+  });
 
 }

--- a/src/log/formats/csv.ts
+++ b/src/log/formats/csv.ts
@@ -9,7 +9,7 @@ export default function csv(log: LogEntry[]): string {
       entry.time.toISOString(),
       eventTypeString.get(entry.eventType),
       entry.ip,
-      entry.userAgent
+      `"${entry.userAgent}"`
     ];
 
   }).join('\n');

--- a/src/log/service.ts
+++ b/src/log/service.ts
@@ -47,7 +47,7 @@ type LogRow = {
 
 export async function findByUser(user: User): Promise<LogEntry[]> {
 
-  const result = await db.query(
+  const result:[LogRow[]] = await db.query(
     'SELECT * FROM user_log WHERE user_id = ?',
     [user.id]
   );

--- a/src/log/types.ts
+++ b/src/log/types.ts
@@ -11,7 +11,6 @@ export enum EventType {
 
 export type LogEntry = {
   time: Date,
-  userId: number,
   ip: string,
   eventType: EventType,
   userAgent: string

--- a/test/log/formats/cvs.ts
+++ b/test/log/formats/cvs.ts
@@ -14,13 +14,20 @@ describe('csv', () => {
           },{
             time: new Date(1),
             ip: '127.0.0.1',
-            eventType: EventType.loginFailed,
+            eventType: EventType.loginFailedInactive,
             userAgent: 'User, Agent'
-          },
+          },{
+            time: new Date(2),
+            ip: '127.0.0.1',
+            eventType: EventType.changePasswordSuccess,
+            userAgent: 'User Agent"'
+          }
         ];
         const expected = `time,eventType,ip,userAgent
-1970-01-01T00:00:00.000Z,login-success,127.0.0.1,"User Agent"
-1970-01-01T00:00:00.001Z,login-failed,127.0.0.1,"User, Agent"`;
+1970-01-01T00:00:00.000Z,login-success,127.0.0.1,User Agent
+1970-01-01T00:00:00.001Z,login-failed-inactive,127.0.0.1,"User, Agent"
+1970-01-01T00:00:00.002Z,change-password-success,127.0.0.1,"User Agent"""
+`;
 
         expect(csv(log)).to.equal(expected)
     });

--- a/test/log/formats/cvs.ts
+++ b/test/log/formats/cvs.ts
@@ -1,0 +1,27 @@
+import { expect } from 'chai';
+
+import { EventType } from '../../../src/log/types'
+import csv from '../../../src/log/formats/csv'
+
+describe('csv', () => {
+    it('should return formatted log string', () => {
+        const log = [
+            {
+            time: new Date(0),
+            ip: '127.0.0.1',
+            eventType: EventType.loginSuccess,
+            userAgent: 'User Agent'
+          },{
+            time: new Date(1),
+            ip: '127.0.0.1',
+            eventType: EventType.loginFailed,
+            userAgent: 'User, Agent'
+          },
+        ];
+        const expected = `time,eventType,ip,userAgent
+1970-01-01T00:00:00.000Z,login-success,127.0.0.1,"User Agent"
+1970-01-01T00:00:00.001Z,login-failed,127.0.0.1,"User, Agent"`;
+
+        expect(csv(log)).to.equal(expected)
+    });
+  });


### PR DESCRIPTION
This fixes an error when viewing a user's log and the user's user agent has a comma in it (`Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.138 Safari/537.36` for example).
```
{ Error: Invalid Record Length: expect 4, got 5 on line 2
    at Parser.__onRow (/home/humiston/Development/a12n-server/node_modules/csv-parse/lib/index.js:689:13)
    at Parser.__parse (/home/humiston/Development/a12n-server/node_modules/csv-parse/lib/index.js:568:40)
    at Parser._transform (/home/humiston/Development/a12n-server/node_modules/csv-parse/lib/index.js:382:22)
    at Parser.Transform._read (_stream_transform.js:190:10)
    at Parser.Transform._write (_stream_transform.js:178:12)
    at doWrite (_stream_writable.js:415:12)
    at writeOrBuffer (_stream_writable.js:399:5)
    at Parser.Writable.write (_stream_writable.js:299:11)
    at parse (/home/humiston/Development/a12n-server/node_modules/csv-parse/lib/index.js:1018:12)
    at Promise (internal/util.js:274:30)
  code: 'CSV_INCONSISTENT_RECORD_LENGTH',
  column: 5,
  empty_lines: 0,
  header: false,
  index: 5,
  invalid_field_length: 0,
  quoting: false,
  lines: 2,
  records: 1,
  record:
   [ '2020-05-09T18:52:14.000Z',
     'login-failed-inactive',
     '::1',
     'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML',
     ' like Gecko) Chrome/81.0.4044.138 Safari/537.36' ] }
```

I also fixed a typing issue I discovered when adding my test. I removed the userId field from the type since it wasn't being used.

For casting `number`s, `eventType` is the only `number` in the `LogEntry`. If I put a branch for only casting the `eventType` and return the value otherwise, then there is an uncovered branch in the code. I can't write a test case for that situation since I can't create a test case that has a different field as a number _and_ satisfy the typing for `LogEntry`. There is a risk that a new field is added to `LogEntry` that is a `number` type which will break this implementation. Hopefully the type check of my test will catch that regression.

This is what I would prefer to implement, specifically:
```
      number: (value, context) => {
        if (context.column === 'eventType') {
          return eventTypeString.get(value);
        }
        return '' + value;
      }
```