### PR TITLE
PKCE Support

### DIFF
--- a/mysql-schema/034-oauth2-codes-pkce.sql
+++ b/mysql-schema/034-oauth2-codes-pkce.sql
@@ -1,0 +1,10 @@
+SET NAMES utf8mb4;
+START TRANSACTION;
+
+INSERT INTO changelog VALUES (34, UNIX_TIMESTAMP());
+
+ALTER TABLE oauth2_codes
+  ADD COLUMN  code_challenge VARCHAR(50) NULL AFTER user_id,
+  ADD COLUMN  code_challenge_method VARCHAR(50) NULL AFTER code_challenge;
+
+COMMIT;

--- a/package-lock.json
+++ b/package-lock.json
@@ -507,6 +507,15 @@
       "integrity": "sha512-t7uW6eFafjO+qJ3BIV2gGUyZs27egcNRkUdalkud+Qa3+kg//f129iuOFivHDXQ+vnU3fDXuwgv0cqMCbcE8sw==",
       "dev": true
     },
+    "@types/chai-as-promised": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/@types/chai-as-promised/-/chai-as-promised-7.1.2.tgz",
+      "integrity": "sha512-PO2gcfR3Oxa+u0QvECLe1xKXOqYTzCmWf0FhLhjREoW3fPAVamjihL7v1MOVLJLsnAMdLcjkfrs01yvDMwVK4Q==",
+      "dev": true,
+      "requires": {
+        "@types/chai": "*"
+      }
+    },
     "@types/color-name": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
@@ -776,6 +785,15 @@
         "type-detect": "^4.0.5"
       }
     },
+    "chai-as-promised": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-7.1.1.tgz",
+      "integrity": "sha512-azL6xMoi+uxu6z4rhWQ1jbdUhOMhis2PvscD/xjLqNMkv3BPPp2JyyuTHOrf9BOosGpNQ11v6BKv/g57RXbiaA==",
+      "dev": true,
+      "requires": {
+        "check-error": "^1.0.2"
+      }
+    },
     "chalk": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -1041,6 +1059,11 @@
       "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
       "dev": true
     },
+    "duplexer": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
+      "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E="
+    },
     "emoji-regex": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
@@ -1099,6 +1122,20 @@
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
     },
+    "event-stream": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
+      "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
+      "requires": {
+        "duplexer": "~0.1.1",
+        "from": "~0",
+        "map-stream": "~0.1.0",
+        "pause-stream": "0.0.11",
+        "split": "0.3",
+        "stream-combiner": "~0.0.4",
+        "through": "~2.3.1"
+      }
+    },
     "fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -1146,6 +1183,11 @@
         "cross-spawn": "^7.0.0",
         "signal-exit": "^3.0.2"
       }
+    },
+    "from": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
+      "integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4="
     },
     "fromentries": {
       "version": "1.2.0",
@@ -1528,8 +1570,7 @@
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-      "dev": true
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
     },
     "istanbul-lib-coverage": {
       "version": "3.0.0",
@@ -1782,6 +1823,11 @@
       "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
       "dev": true
     },
+    "map-stream": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
+      "integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ="
+    },
     "markdown-it": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-10.0.0.tgz",
@@ -2005,6 +2051,11 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.0.tgz",
       "integrity": "sha512-ASCL5U13as7HhOExbT6OlWJJUV/lLzL2voOSP1UVehpRD8FbSrSDjfScK/KwAvVTI5AS6r4VwbOMlIqtvRidnA=="
+    },
+    "node-cleanup": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/node-cleanup/-/node-cleanup-2.1.2.tgz",
+      "integrity": "sha1-esGavSl+Caf3KnFUXZUbUX5N3iw="
     },
     "node-environment-flags": {
       "version": "1.0.6",
@@ -2499,6 +2550,14 @@
       "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
       "dev": true
     },
+    "pause-stream": {
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
+      "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
+      "requires": {
+        "through": "~2.3"
+      }
+    },
     "picomatch": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
@@ -2562,6 +2621,14 @@
       "dev": true,
       "requires": {
         "fromentries": "^1.2.0"
+      }
+    },
+    "ps-tree": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/ps-tree/-/ps-tree-1.2.0.tgz",
+      "integrity": "sha512-0VnamPPYHl4uaU/nSFeZZpR21QAWRz+sRv4iW9+v/GS/J5U5iZB5BNN6J0RMoOvdx2gWM2+ZFMIm58q24e4UYA==",
+      "requires": {
+        "event-stream": "=3.3.4"
       }
     },
     "pseudomap": {
@@ -2822,6 +2889,14 @@
         }
       }
     },
+    "split": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
+      "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
+      "requires": {
+        "through": "2"
+      }
+    },
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -2836,6 +2911,19 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
       "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
+    },
+    "stream-combiner": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
+      "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
+      "requires": {
+        "duplexer": "~0.1.1"
+      }
+    },
+    "string-argv": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.1.2.tgz",
+      "integrity": "sha512-mBqPGEOMNJKXRo7z0keX0wlAhbBAjilUdPW13nN0PecVryZxdHIeM7TqbsSUA7VYuS00HGC6mojP7DlQzfa9ZA=="
     },
     "string-width": {
       "version": "1.0.2",
@@ -2978,6 +3066,11 @@
       "resolved": "https://registry.npmjs.org/thirty-two/-/thirty-two-1.0.2.tgz",
       "integrity": "sha1-TKL//AKlEpDSdEueP1V2k8prYno="
     },
+    "through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+    },
     "to-fast-properties": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
@@ -3016,6 +3109,56 @@
           "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
           "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
           "dev": true
+        }
+      }
+    },
+    "tsc-watch": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/tsc-watch/-/tsc-watch-4.2.3.tgz",
+      "integrity": "sha512-M1Lo37+ggVfavGX3ObUVMz9QBH7moqq2RlmBdxnz6a6etwecetznZ/ZgYOi2c9HQ4Ki2qStj7V9J/gSf0rThig==",
+      "requires": {
+        "cross-spawn": "^5.1.0",
+        "node-cleanup": "^2.1.2",
+        "ps-tree": "^1.2.0",
+        "string-argv": "^0.1.1",
+        "strip-ansi": "^4.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+        },
+        "cross-spawn": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+          "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+          "requires": {
+            "lru-cache": "^4.0.1",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
+          }
+        },
+        "shebang-command": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+          "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+          "requires": {
+            "shebang-regex": "^1.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+          "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
         }
       }
     },
@@ -3139,7 +3282,6 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
       "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-      "dev": true,
       "requires": {
         "isexe": "^2.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "prepublishOnly": "make build",
     "test": "make lint test",
     "tsc": "tsc",
-    "start": "node ./dist/app.js"
+    "start": "node ./dist/app.js",
+    "start:watch": "tsc-watch --onSuccess 'node dist/app.js'"
   },
   "repository": {
     "type": "git",
@@ -37,6 +38,7 @@
   "devDependencies": {
     "@types/bcrypt": "^3.0.0",
     "@types/chai": "^4.2.11",
+    "@types/chai-as-promised": "^7.1.2",
     "@types/handlebars": "^4.1.0",
     "@types/mocha": "^7.0.2",
     "@types/node": "^10.17.21",
@@ -44,6 +46,7 @@
     "@types/otplib": "^10.0.0",
     "@types/sinon": "^9.0.0",
     "chai": "^4.2.0",
+    "chai-as-promised": "^7.1.1",
     "hal-types": "^1.0.0",
     "mocha": "^7.1.2",
     "nyc": "^15.0.1",
@@ -73,6 +76,7 @@
     "handlebars": "^4.7.6",
     "mysql2": "^2.1.0",
     "nodemailer": "^6.4.6",
-    "otplib": "^12.0.1"
+    "otplib": "^12.0.1",
+    "tsc-watch": "^4.2.3"
   }
 }

--- a/src/oauth2/controller/authorize.ts
+++ b/src/oauth2/controller/authorize.ts
@@ -43,7 +43,7 @@ class AuthorizeController extends Controller {
     const responseType = ctx.query.response_type;
     const redirectUri = ctx.query.redirect_uri;
     const codeChallenge = ctx.query.code_challenge;
-    const codeChallengeMethod = ctx.query.code_challenge_method ? ctx.query.code_challenge_method : 'plain';
+    const codeChallengeMethod = ctx.query.code_challenge_method ? (<'S256'>ctx.query.code_challenge_method) : 'plain';
     const grantType = responseType === 'code' ? 'authorization_code' : 'implicit';
 
     try {
@@ -119,7 +119,7 @@ class AuthorizeController extends Controller {
     const redirectUri = ctx.request.body.redirect_uri;
     const responseType = ctx.request.body.response_type;
     const codeChallenge = ctx.request.body.code_challenge;
-    const codeChallengeMethod = ctx.request.body.code_challenge_method;
+    const codeChallengeMethod = ctx.request.body.code_challenge_method ? (<'S256'>ctx.request.body.code_challenge_method) : 'plain';
     const grantType = responseType === 'code' ? 'authorization_code' : 'implicit';
 
     try {
@@ -218,7 +218,7 @@ class AuthorizeController extends Controller {
     redirectUri: string,
     state: string|undefined,
     codeChallenge: string|undefined,
-    codeChallengeMethod: string|undefined,
+    codeChallengeMethod: 'S256' | 'plain' | undefined
   ) {
 
     const code = await oauth2Service.generateCodeForUser(

--- a/src/oauth2/controller/authorize.ts
+++ b/src/oauth2/controller/authorize.ts
@@ -29,13 +29,21 @@ class AuthorizeController extends Controller {
     if (!ctx.query.redirect_uri) {
       throw new InvalidRequest('The "redirect_uri" parameter must be provided');
     }
+    if (ctx.query.response_type === 'code') {
+      if (ctx.query.code_challenge_method && !['plain', 'S256'].includes(ctx.query.code_challenge_method)) {
+        throw new InvalidRequest('The "code_challenge_method" must be "plain" or "S256"');
+      }
+      if (!ctx.query.code_challenge && ctx.query.code_challenge_method) {
+        throw new InvalidRequest('The "code_challenge" must be provided');
+      }
+    }
     const clientId = ctx.query.client_id;
     const state = ctx.query.state;
     // const scope = ctx.query.scope;
     const responseType = ctx.query.response_type;
     const redirectUri = ctx.query.redirect_uri;
     const codeChallenge = ctx.query.code_challenge;
-    const codeChallengeMethod = ctx.query.code_challenge_method;
+    const codeChallengeMethod = ctx.query.code_challenge_method ? ctx.query.code_challenge_method : 'plain';
     const grantType = responseType === 'code' ? 'authorization_code' : 'implicit';
 
     try {
@@ -235,7 +243,7 @@ class AuthorizeController extends Controller {
   }
 
   /**
-   * We're overriding the default dipatcher to catch OAuth2 errors.
+   * We're overriding the default dispatcher to catch OAuth2 errors.
    */
   async dispatch(ctx: Context): Promise<void> {
 

--- a/src/oauth2/controller/token.ts
+++ b/src/oauth2/controller/token.ts
@@ -83,7 +83,6 @@ class TokenController extends Controller {
     if (!ctx.request.body.redirect_uri) {
       throw new InvalidRequest('The "redirect_uri" property is required');
     }
-
     if (!await oauth2Service.validateRedirectUri(oauth2Client, ctx.request.body.redirect_uri)) {
       log(EventType.oauth2BadRedirect, ctx);
       throw new InvalidRequest('This value for "redirect_uri" is not recognized.');

--- a/src/oauth2/controller/token.ts
+++ b/src/oauth2/controller/token.ts
@@ -83,11 +83,12 @@ class TokenController extends Controller {
     if (!ctx.request.body.redirect_uri) {
       throw new InvalidRequest('The "redirect_uri" property is required');
     }
+
     if (!await oauth2Service.validateRedirectUri(oauth2Client, ctx.request.body.redirect_uri)) {
       log(EventType.oauth2BadRedirect, ctx);
       throw new InvalidRequest('This value for "redirect_uri" is not recognized.');
     }
-    const token = await oauth2Service.generateTokenFromCode(oauth2Client, ctx.request.body.code);
+    const token = await oauth2Service.generateTokenFromCode(oauth2Client, ctx.request.body.code, ctx.request.body.code_verifier);
 
     ctx.response.type = 'application/json';
     ctx.response.body = {

--- a/src/oauth2/service.ts
+++ b/src/oauth2/service.ts
@@ -6,7 +6,7 @@ import { getSetting } from '../server-settings';
 import * as userService from '../user/service';
 import { User } from '../user/types';
 import { InvalidGrant, InvalidRequest, UnauthorizedClient} from './errors';
-import { OAuth2Client, OAuth2Code, OAuth2Token } from './types';
+import { CodeChallengeMethod, OAuth2Client, OAuth2Code, OAuth2Token } from './types';
 
 type OAuth2ClientRecord = {
   id: number,
@@ -171,7 +171,7 @@ export async function generateTokenFromCode(client: OAuth2Client, code: string, 
 
 }
 
-export function validatePKCE(codeVerifier: string|undefined, codeChallenge: string|undefined, codeChallengeMethod: string|undefined) {
+export function validatePKCE(codeVerifier: string|undefined, codeChallenge: string|undefined, codeChallengeMethod: CodeChallengeMethod) {
   if (!codeChallenge && !codeVerifier) {
     // This request was not initiated with PKCE support, so ignore the validation
     return;
@@ -284,7 +284,7 @@ type OAuth2CodeRecord = {
   code: string,
   user_id: number,
   code_challenge: string|undefined,
-  code_challenge_method: string|undefined,
+  code_challenge_method: CodeChallengeMethod
   created: number,
 };
 

--- a/src/oauth2/types.ts
+++ b/src/oauth2/types.ts
@@ -20,3 +20,5 @@ export type OAuth2Token = {
 export type OAuth2Code = {
   code: string;
 };
+
+export type CodeChallengeMethod = 'plain' | 'S256';

--- a/test/oauth2/controller/authorize.ts
+++ b/test/oauth2/controller/authorize.ts
@@ -102,6 +102,24 @@ describe('AuthorizeController', () => {
             )).to.be.true
         });
 
+        it('should pass valid parameters and call code redirect without PKCE', async() => {
+            params.delete('code_challenge');
+            params.delete('code_challenge_method');
+
+            const request = new MemoryRequest('GET', '?' + params);
+            const context = new BaseContext(request, new MemoryResponse());
+            context.state = {
+                session: {
+                    user: {}
+                }
+            };
+
+            await authorize.get(context);
+            expect(codeRedirectMock.calledOnceWithExactly(
+                context, oauth2Client, 'redirect-uri', 'state', undefined, undefined
+            )).to.be.true
+        });
+
         it('should fail code challenge validation', async() => {
             params.set('code_challenge_method', 'bogus-method');
 
@@ -176,6 +194,24 @@ describe('AuthorizeController', () => {
             await authorize.post(context);
             expect(codeRedirectMock.calledOnceWithExactly(
                 context, oauth2Client, 'redirect-uri', 'state', 'challenge-code', 'plain'
+            )).to.be.true
+        });
+
+        it('should pass valid parameters and call code redirect without PKCE', async() => {
+            const request = new MemoryRequest('POST', '/');
+            delete body.code_challenge;
+            delete body.code_challenge_method;
+            request.body = body;
+            const context = new BaseContext(request, new MemoryResponse());
+            context.state = {
+                session: {
+                    user: {}
+                }
+            };
+
+            await authorize.post(context);
+            expect(codeRedirectMock.calledOnceWithExactly(
+                context, oauth2Client, 'redirect-uri', 'state', undefined, undefined
             )).to.be.true
         });
 

--- a/test/oauth2/controller/authorize.ts
+++ b/test/oauth2/controller/authorize.ts
@@ -1,0 +1,98 @@
+import { MemoryRequest, BaseContext, MemoryResponse } from '@curveball/core';
+import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import sinon from 'sinon';
+
+import { InvalidRequest } from '../../../src/oauth2/errors';
+import * as oauth2Service from '../../../src/oauth2/service';
+import { OAuth2Client } from '../../../src/oauth2/types';
+import authorize from '../../../src/oauth2/controller/authorize'
+
+chai.use(chaiAsPromised);
+const expect = chai.expect;
+
+describe('AuthorizeController', () => {
+    const sandbox = sinon.createSandbox();
+    let codeRedirectMock: sinon.SinonStub;
+    const oauth2Client: OAuth2Client = {
+        id: 1,
+        clientId: 'client-id',
+        clientSecret: Buffer.from('client-secret', 'utf-8'),
+        user: {
+            id: 1,
+            identity: 'identity',
+            nickname: 'nickname',
+            created: new Date(1),
+            type: 'user',
+            active: true
+        },
+        allowedGrantTypes: ['authorization_code'],
+    };
+    let params: URLSearchParams;
+
+    beforeEach(function () {
+        sandbox.stub(oauth2Service, 'getClientByClientId').returns(Promise.resolve(oauth2Client));
+        sandbox.stub(oauth2Service, 'validateRedirectUri').returns(Promise.resolve(true));
+        codeRedirectMock = sandbox.stub(authorize, 'codeRedirect');
+
+        params = new URLSearchParams({
+            response_type: 'code',
+            client_id: 'client-id',
+            redirect_uri: 'redirect-uri',
+            code_challenge: 'challenge-code',
+            code_challenge_method: 'plain',
+            state: 'state',
+          });
+    });
+
+    afterEach(() => {
+        sandbox.restore();
+    });
+
+    describe('get', () => {
+        it('should pass valid parameters and call code redirect', async() => {
+            const request = new MemoryRequest('GET', '?' + params);
+            const context = new BaseContext(request, new MemoryResponse());
+            context.state = {
+                session: {
+                    user: {}
+                }
+            };
+
+            await authorize.get(context);
+            expect(codeRedirectMock.calledOnceWithExactly(
+                context, oauth2Client, 'redirect-uri', 'state', 'challenge-code', 'plain'
+            )).to.be.true
+        });
+
+        it('should fail code challenge validation', async() => {
+            params.set('code_challenge_method', 'bogus-method');
+
+            const request = new MemoryRequest('GET', '?' + params);
+            const context = new BaseContext(request, new MemoryResponse());
+            context.state = {
+                session: {
+                    user: {}
+                }
+            };
+
+
+            await expect(authorize.get(context)).to.be.rejectedWith(InvalidRequest, 'The "code_challenge_method" must be "plain" or "S256"')
+        });
+
+        it('should fail when code method is provided but not challenge', async() => {
+            params.delete('code_challenge');
+
+            const request = new MemoryRequest('GET', '?' + params);
+            const context = new BaseContext(request, new MemoryResponse());
+            context.state = {
+                session: {
+                    user: {}
+                }
+            };
+
+
+            await expect(authorize.get(context)).to.be.rejectedWith(InvalidRequest, 'The "code_challenge" must be provided')
+        });
+    });
+});

--- a/test/oauth2/services.ts
+++ b/test/oauth2/services.ts
@@ -1,0 +1,40 @@
+import { expect } from 'chai';
+
+import { InvalidGrant } from '../../src/oauth2/errors';
+import { validatePKCE } from '../../src/oauth2/service'
+
+describe('oauth2 services', () => {
+    describe('oauth2 validatePKCE', () => {
+        it('should validate the sha256 codeVerifier', () => {
+            const codeVerifier = 'BwUZNJDORebJpJCDjEj836gqlSSwoKBP1_s3s96Y3AA';
+            const codeChallenge = 'VoyAMKJrUrfPcl7WoRJwj-MKNhgqTUMes97-HGvlbsA';
+            const codeChallengeMethod = 'sha256'
+
+            expect(() => validatePKCE(codeVerifier, codeChallenge, codeChallengeMethod)).to.not.throw();
+        });
+
+        it('should fail to validate the sha256 codeVerifier', () => {
+            const codeVerifier = 'bogus-code';
+            const codeChallenge = 'VoyAMKJrUrfPcl7WoRJwj-MKNhgqTUMes97-HGvlbsA';
+            const codeChallengeMethod = 'sha256'
+
+            expect(() => validatePKCE(codeVerifier, codeChallenge, codeChallengeMethod)).to.throw(InvalidGrant, 'The code verifier does not match the code challenge');
+        });
+
+        it('should validate the plain codeVerifier', () => {
+            const codeVerifier = 'plain-code';
+            const codeChallenge = 'plain-code';
+            const codeChallengeMethod = 'plain'
+
+            expect(() => validatePKCE(codeVerifier, codeChallenge, codeChallengeMethod)).to.not.throw();
+        });
+
+        it('should fail to validate the plain codeVerifier', () => {
+            const codeVerifier = 'bogus-code';
+            const codeChallenge = 'plain-code';
+            const codeChallengeMethod = 'plain'
+
+            expect(() => validatePKCE(codeVerifier, codeChallenge, codeChallengeMethod)).to.throw(InvalidGrant, 'The code verifier does not match the code challenge');
+        });
+    });
+  });

--- a/test/oauth2/services.ts
+++ b/test/oauth2/services.ts
@@ -1,22 +1,22 @@
 import { expect } from 'chai';
 
-import { InvalidGrant } from '../../src/oauth2/errors';
+import { InvalidGrant, InvalidRequest } from '../../src/oauth2/errors';
 import { validatePKCE } from '../../src/oauth2/service'
 
 describe('oauth2 services', () => {
     describe('oauth2 validatePKCE', () => {
         it('should validate the sha256 codeVerifier', () => {
-            const codeVerifier = 'BwUZNJDORebJpJCDjEj836gqlSSwoKBP1_s3s96Y3AA';
-            const codeChallenge = 'VoyAMKJrUrfPcl7WoRJwj-MKNhgqTUMes97-HGvlbsA';
-            const codeChallengeMethod = 'sha256'
+            const codeVerifier = 'S4O8Jlv9ltbnCgmvzfIi9NnQ5d7CzSpG8QqnV7NGGQ8';
+            const codeChallenge = 'SYyy6WKPGGJ46cMDMJ6ro9tgRJHoWOqPrEAcSw8wmc8';
+            const codeChallengeMethod = 'S256'
 
             expect(() => validatePKCE(codeVerifier, codeChallenge, codeChallengeMethod)).to.not.throw();
         });
 
         it('should fail to validate the sha256 codeVerifier', () => {
             const codeVerifier = 'bogus-code';
-            const codeChallenge = 'VoyAMKJrUrfPcl7WoRJwj-MKNhgqTUMes97-HGvlbsA';
-            const codeChallengeMethod = 'sha256'
+            const codeChallenge = 'SYyy6WKPGGJ46cMDMJ6ro9tgRJHoWOqPrEAcSw8wmc8';
+            const codeChallengeMethod = 'S256'
 
             expect(() => validatePKCE(codeVerifier, codeChallenge, codeChallengeMethod)).to.throw(InvalidGrant, 'The code verifier does not match the code challenge');
         });
@@ -35,6 +35,14 @@ describe('oauth2 services', () => {
             const codeChallengeMethod = 'plain'
 
             expect(() => validatePKCE(codeVerifier, codeChallenge, codeChallengeMethod)).to.throw(InvalidGrant, 'The code verifier does not match the code challenge');
+        });
+
+        it('should fail if the code verifier is not supplied', () => {
+            const codeVerifier:undefined = undefined;
+            const codeChallenge = 'plain-code';
+            const codeChallengeMethod = 'plain'
+
+            expect(() => validatePKCE(codeVerifier, codeChallenge, codeChallengeMethod)).to.throw(InvalidRequest, 'The code verifier was not supplied');
         });
     });
   });


### PR DESCRIPTION
This is just a draft PR, but I think it's feature complete. I just want to add some more tests for the other parts of the code I touched.

The RFC gives the option of storing the code within the server or as part of the `code` that is returned from the authorization request. That seems weird to me, tbh. Since the authorization codes are short-lived in stored in our DB, I figured it was easiest just to store the code challenge, too.