### PR TITLE
Add typescript type checking back to lint target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ test:
 	nyc mocha
 
 lint:
+	npx tsc --noemit
 	npx eslint --quiet 'src/**/*.ts' 'test/**/*.ts'
 
 fix:


### PR DESCRIPTION
When `tslint` was removed in #176, it also removed Typescript type checking during the testing step. This adds it make to the `lint` make target. 

I could also make a new `check-types` make target and have that be ran as part of the `test` npm script if you all think that would be more appropriate.