### PR TITLE
Revoke endpoint

### DIFF
--- a/src/log/types.ts
+++ b/src/log/types.ts
@@ -7,6 +7,7 @@ export enum EventType {
   resetPasswordSuccess,
   loginFailedInactive,
   webAuthnFailed,
+  tokenRevoked,
   oauth2BadRedirect = 11,
 }
 
@@ -18,13 +19,14 @@ export type LogEntry = {
 };
 
 export const eventTypeString = new Map<EventType, string>([
-  [EventType.loginSuccess,      'login-success'],
-  [EventType.loginFailed,       'login-failed'],
-  [EventType.totpFailed,        'totp-failed'],
-  [EventType.webAuthnFailed,    'webauthn-failed'],
+  [EventType.loginSuccess,          'login-success'],
+  [EventType.loginFailed,           'login-failed'],
+  [EventType.totpFailed,            'totp-failed'],
+  [EventType.webAuthnFailed,        'webauthn-failed'],
   [EventType.changePasswordSuccess, 'change-password-success'],
-  [EventType.resetPasswordRequest, 'reset-password-request'],
-  [EventType.resetPasswordSuccess, 'reset-password-success'],
-  [EventType.loginFailedInactive, 'login-failed-inactive'],
-  [EventType.oauth2BadRedirect, 'oauth2-badredirect'],
+  [EventType.resetPasswordRequest,  'reset-password-request'],
+  [EventType.resetPasswordSuccess,  'reset-password-success'],
+  [EventType.loginFailedInactive,   'login-failed-inactive'],
+  [EventType.tokenRevoked,          'token-revoked'],
+  [EventType.oauth2BadRedirect,     'oauth2-badredirect'],
 ]);

--- a/src/middleware/login.ts
+++ b/src/middleware/login.ts
@@ -11,6 +11,7 @@ const whitelistPath = [
   '/reset-password',
   '/token',
   '/introspect',
+  '/revoke',
 ];
 
 

--- a/src/oauth2/controller/revoke.ts
+++ b/src/oauth2/controller/revoke.ts
@@ -1,0 +1,37 @@
+import Controller from '@curveball/controller';
+import { Context } from '@curveball/core';
+import log from '../../log/service';
+import { EventType } from '../../log/types';
+import { revokeByAccessRefreshToken } from '../service';
+import { OAuth2Client } from '../types';
+import {
+  getOAuth2ClientFromBasicAuth,
+  getOAuth2ClientFromBody,
+} from '../utilities';
+
+
+class RevokeController extends Controller {
+
+  async post(ctx: Context) {
+
+    let oauth2Client: OAuth2Client;
+
+    if (ctx.request.headers.has('Authorization')) {
+      oauth2Client = await getOAuth2ClientFromBasicAuth(ctx);
+    } else {
+      oauth2Client = await getOAuth2ClientFromBody(ctx);
+    }
+
+    const token = ctx.request.body.token;
+
+    await revokeByAccessRefreshToken(oauth2Client, token);
+
+    log(EventType.tokenRevoked, ctx);
+
+    ctx.status = 200;
+
+  }
+
+}
+
+export default new RevokeController();

--- a/src/oauth2/formats/json.ts
+++ b/src/oauth2/formats/json.ts
@@ -10,6 +10,8 @@ export function metadata() {
     service_documentation: 'https://evertpot.com/',
     ui_locales_supported: ['en'],
     introspection_endpoint: '/introspect',
+    revocation_endpoint: '/revoke',
+    revocation_endpoint_auth_methods_supported: ['client_secret_basic'],
   };
 
 }

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -35,7 +35,6 @@ const routes = [
   router('/token', oauth2Token),
   router('/revoke', oauth2Revoke),
 
-
   router('/create-user', createUser),
 
   router('/login', login),

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -13,6 +13,7 @@ import loginWebAuthn from './mfa/webauthn/controller/login';
 import logout from './logout/controller';
 import oauth2Authorize from './oauth2/controller/authorize';
 import oauth2Token from './oauth2/controller/token';
+import oauth2Revoke from './oauth2/controller/revoke';
 import privilegeCollection from './privilege/controller/collection';
 import privilegeItem from './privilege/controller/item';
 import register from './register/controller/user';
@@ -32,6 +33,7 @@ const routes = [
 
   router('/authorize', oauth2Authorize),
   router('/token', oauth2Token),
+  router('/revoke', oauth2Revoke),
 
 
   router('/create-user', createUser),


### PR DESCRIPTION
New endpoint for revoking access/refresh tokens. The current implementation always revokes the access/refresh token pair.

I'm a bit confused on how to interrupt the first part of the following from the end of section 2.1. For the second part, that will be true since refresh and access tokens are stored in the same row.
> If the particular
   token is a refresh token and the authorization server supports the
   revocation of access tokens, then the authorization server SHOULD
   also invalidate all access tokens based on the same authorization
   grant (see Implementation Note).  If the token passed to the request
   is an access token, the server MAY revoke the respective refresh
   token as well.

Let me use an example to see if my interruption is correct. I request 2 tokens using the authorization code grant type and then 1 with the client credentials. If I try and revoke 1 of my refresh tokens I got from the authorization code grant, I should also revoke the _other_ access/refresh token pair from the authorization grant? And the access/refresh token pair from the client credentials grant remains?

This paragraph is the rationale for revoking the access/refresh pair together regardless of which is passed. I'm just not sure if I should be revoking _all_ of the access tokens when a refresh token is passed.

Resovle #20