### PR TITLE
Fix failed oauth login not able to log in

### DIFF
--- a/src/login/controller/login.ts
+++ b/src/login/controller/login.ts
@@ -72,8 +72,12 @@ class LoginController extends Controller {
 
   redirectToLogin(ctx: Context, msg: string, error: string) {
 
+    const params: any = { msg, error };
+    if (ctx.request.body && ctx.request.body.continue) {
+      params['continue'] = ctx.request.body.continue;
+    }
     ctx.response.status = 303;
-    ctx.response.headers.set('Location', '/login?' + querystring.stringify({ msg, error }));
+    ctx.response.headers.set('Location', '/login?' + querystring.stringify(params));
 
   }
 


### PR DESCRIPTION
During the oauth flow, the user is redirected to `/login` when the login fails. This prevents the user from fixing their mistake and finishing the oauth flow (since the user is not redirected back to `/authorize`). I broke this in #174 when I unified the login flows across both oauth and browser flows.

When the user is redirected to `/login` during the oauth flow, a `continue` param is added which redirects the user back to `/authorize` once login is completed. The `continue` param is missing when the user fails to login and is redirected back to the login page. This fix adds the `continue` param when the user is redirected to `/login` after a failed attempt.

Verified manually in the browser and with Postman.