### PR TITLE
Fix reset password endpoint for some tokens.

### DIFF
--- a/src/reset-password/service.ts
+++ b/src/reset-password/service.ts
@@ -51,7 +51,7 @@ export async function sendResetPasswordEmail(user: User) {
  * This function will create a unique token then store it in the databse
  */
 export async function createToken(user: User): Promise<string> {
-  const token = crypto.randomBytes(32).toString('base64').replace('+', '-').replace('/', '_').replace(/=+$/, '');
+  const token = crypto.randomBytes(32).toString('base64').replace(/+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
   const query = 'INSERT INTO reset_password_token SET user_id = ?, token = ?, expires_at = UNIX_TIMESTAMP() + ?, created_at = UNIX_TIMESTAMP()';
 
   await database.query(query, [


### PR DESCRIPTION
The regex we use for replacing / to _ only replaced the first /. If a
token gets generated with 2 slashes, the route will result in a 404.