### PR TITLE
Update cookie options.

### DIFF
--- a/src/main-mw.ts
+++ b/src/main-mw.ts
@@ -19,6 +19,8 @@ export default function(): Middleware {
     problem(),
     session({
       store: 'memory',
+      cookieName: 'A12N',
+      expiry: 60*60*24*7,
     }),
     login(),
     bodyParser(),


### PR DESCRIPTION
We'll keep users logged in for 7 days by default now. Also changing the
cookie name to make it less likely to clash with other curveball
applications.