### PR TITLE
Logging out will also expire dependent oauth2 tokens.

### DIFF
--- a/mysql-schema/039-oauth-token-session.sql
+++ b/mysql-schema/039-oauth-token-session.sql
@@ -1,0 +1,12 @@
+SET NAMES utf8mb4;
+START TRANSACTION;
+
+INSERT INTO changelog VALUES (39, UNIX_TIMESTAMP());
+
+ALTER TABLE oauth2_tokens
+  ADD browser_session_id VARCHAR(200) NULL;
+
+ALTER TABLE oauth2_codes
+  ADD browser_session_id VARCHAR(200) NULL;
+
+COMMIT;

--- a/src/logout/controller.ts
+++ b/src/logout/controller.ts
@@ -1,10 +1,11 @@
 import Controller from '@curveball/controller';
 import { Context } from '@curveball/core';
 import { logoutForm } from './formats/html';
+import * as oauth2Service from '../oauth2/service';
 
 class LogoutController extends Controller {
 
-  async get(ctx: Context) {
+  get(ctx: Context) {
 
     ctx.response.type = 'text/html';
     ctx.response.body = logoutForm(
@@ -17,6 +18,9 @@ class LogoutController extends Controller {
 
   async post(ctx: Context) {
 
+    await oauth2Service.invalidateTokensByBrowserSessionId(
+      ctx.state.sessionId
+    );
     ctx.state.session = null;
     ctx.state.sessionId = null;
     ctx.status = 303;

--- a/src/oauth2/controller/authorize.ts
+++ b/src/oauth2/controller/authorize.ts
@@ -124,6 +124,7 @@ class AuthorizeController extends Controller {
       ctx.state.session.user,
       codeChallenge,
       codeChallengeMethod,
+      ctx.state.sessionId,
     );
 
     ctx.status = 302;

--- a/src/oauth2/types.ts
+++ b/src/oauth2/types.ts
@@ -1,12 +1,28 @@
 import { User } from '../user/types';
 
 export type OAuth2Token = {
+  // OAuth2 Access token
   accessToken: string,
+
+  // OAuth2 Refresh token
   refreshToken: string,
+
+  // Unix timestamp of when the token expires (in seconds)
   accessTokenExpires: number,
+
+  // Type of token. Only 'bearer' is supported rn.
   tokenType: 'bearer',
+
+  // The user this token belongs to
   user: User,
+
+  // The OAuth2 client (app) that created this session
   clientId: number,
+
+  // If the token was created via a browser-flow, such as implicit or
+  // authorization_code, this will contain the browser session cookie
+  // id.
+  browserSessionId?: string,
 };
 
 export type OAuth2Code = {


### PR DESCRIPTION
When a user hits the /logout endpoint, and logs out, all oauth2 tokens
that were created by the current session will also get removed.