### PR TITLE
fix for `continue` query params.

### DIFF
--- a/src/logout/controller.ts
+++ b/src/logout/controller.ts
@@ -26,7 +26,7 @@ class LogoutController extends Controller {
     ctx.status = 303;
     ctx.redirect(
       303,
-      ctx.query.continue || '/'
+      ctx.request.body.continue || '/'
     );
 
   }


### PR DESCRIPTION
`ctx.query.continue` doesn't contain anything, but `ctx.request.body.continue` still contains the redirect URL.