### PR TITLE
Fix OAuth2 error handler.

### DIFF
--- a/src/oauth2/controller/authorize.ts
+++ b/src/oauth2/controller/authorize.ts
@@ -2,7 +2,7 @@ import Controller from '@curveball/controller';
 import { Context } from '@curveball/core';
 import { NotFound } from '@curveball/http-errors';
 import querystring from 'querystring';
-import { InvalidClient, InvalidRequest, serializeError, UnsupportedGrantType } from '../errors';
+import { InvalidClient, InvalidRequest, UnsupportedGrantType } from '../errors';
 import * as oauth2Service from '../service';
 import { CodeChallengeMethod } from '../types';
 import { OAuth2Client } from '../../oauth2-client/types';
@@ -146,25 +146,6 @@ class AuthorizeController extends Controller {
 
     ctx.response.status = 302;
     ctx.response.headers.set('Location', '/login?' + querystring.stringify(params));
-
-  }
-
-  /**
-   * We're overriding the default dispatcher to catch OAuth2 errors.
-   */
-  async dispatch(ctx: Context): Promise<void> {
-
-    try {
-      await super.dispatch(ctx);
-    } catch (err) {
-      if (err.errorCode) {
-        /* eslint-disable-next-line no-console */
-        console.log(err);
-        serializeError(ctx, err);
-      } else {
-        throw err;
-      }
-    }
 
   }
 

--- a/src/oauth2/controller/token.ts
+++ b/src/oauth2/controller/token.ts
@@ -4,7 +4,7 @@ import log from '../../log/service';
 import { EventType } from '../../log/types';
 import * as userService from '../../user/service';
 import { User } from '../../user/types';
-import { InvalidGrant, InvalidRequest, serializeError, UnsupportedGrantType } from '../errors';
+import { InvalidGrant, InvalidRequest, UnsupportedGrantType } from '../errors';
 import * as oauth2Service from '../service';
 import { OAuth2Client } from '../../oauth2-client/types';
 import {
@@ -163,25 +163,6 @@ class TokenController extends Controller {
   sendCORSHeaders(ctx: Context) {
 
     ctx.response.headers.set('Access-Control-Allow-Origin', '*');
-
-  }
-
-  /**
-   * We're overriding the default dipatcher to catch OAuth2 errors.
-   */
-  async dispatch(ctx: Context): Promise<void> {
-
-    try {
-      await super.dispatch(ctx);
-    } catch (err) {
-      if (err.errorCode) {
-        /* eslint-disable-next-line no-console */
-        console.log(err);
-        serializeError(ctx, err);
-      } else {
-        throw err;
-      }
-    }
 
   }
 

--- a/src/oauth2/errors.ts
+++ b/src/oauth2/errors.ts
@@ -1,18 +1,12 @@
-import { Context } from '@curveball/core';
 import { HttpError } from '@curveball/http-errors';
 
-interface OAuthError extends HttpError {
+interface OAuth2Error extends HttpError {
   errorCode: string;
 }
 
-export function serializeError(ctx: Context, err: OAuthError) {
+export function isOAuth2Error(err: Error): err is OAuth2Error {
 
-  ctx.response.status = err.httpStatus;
-  ctx.response.headers.set('Content-Type', 'application/json');
-  ctx.response.body = {
-    error: err.errorCode,
-    error_description: err.message,
-  };
+  return typeof (err as any).errorCode === 'string';
 
 }
 
@@ -20,7 +14,7 @@ export function serializeError(ctx: Context, err: OAuthError) {
  * The request is missing a required parameter, includes an invalid parameter
  * value, includes a parameter more than once or is otherwise malformed.
  */
-export class InvalidRequest extends Error implements OAuthError {
+export class InvalidRequest extends Error implements OAuth2Error {
 
   httpStatus = 400;
   errorCode = 'invalid_request';
@@ -31,7 +25,7 @@ export class InvalidRequest extends Error implements OAuthError {
  * The client is not authorized to request an authorization code using this
  * method
  */
-export class UnauthorizedClient extends Error implements OAuthError {
+export class UnauthorizedClient extends Error implements OAuth2Error {
 
   httpStatus = 403;
   errorCode = 'unauthorized_client';
@@ -41,7 +35,7 @@ export class UnauthorizedClient extends Error implements OAuthError {
 /**
  * The resource owner or authorization server denied the request
  */
-export class AccessDenied extends Error implements OAuthError {
+export class AccessDenied extends Error implements OAuth2Error {
 
   httpStatus = 403;
   errorCode = 'access_denied';
@@ -52,7 +46,7 @@ export class AccessDenied extends Error implements OAuthError {
  * The authorization server does not support obtaining an authorization code
  * using this method
  */
-export class UnsupportedResponseType extends Error implements OAuthError {
+export class UnsupportedResponseType extends Error implements OAuth2Error {
 
   httpStatus = 400;
   errorCode = 'unsupported_response_type';
@@ -62,7 +56,7 @@ export class UnsupportedResponseType extends Error implements OAuthError {
 /**
  * The requested scope is invalid, unknown or malformed
  */
-export class InvalidScope extends Error implements OAuthError {
+export class InvalidScope extends Error implements OAuth2Error {
 
   httpStatus = 400;
   errorCode = 'invalid_scope';
@@ -79,7 +73,7 @@ export class InvalidScope extends Error implements OAuthError {
  * the "WWW-Authenticate" response header field matching the authentication
  * scheme used by the client.
  */
-export class InvalidClient extends Error implements OAuthError {
+export class InvalidClient extends Error implements OAuth2Error {
 
   httpStatus = 401;
   errorCode = 'invalid_client';
@@ -92,7 +86,7 @@ export class InvalidClient extends Error implements OAuthError {
  * the redirection URI used in the authorization request, or was issued to
  * another client.
  */
-export class InvalidGrant extends Error implements OAuthError {
+export class InvalidGrant extends Error implements OAuth2Error {
 
   httpStatus = 400;
   errorCode = 'invalid_grant';
@@ -102,7 +96,7 @@ export class InvalidGrant extends Error implements OAuthError {
 /**
  * The authorization grant type is not supported by the authorization server.
  */
-export class UnsupportedGrantType extends Error implements OAuthError {
+export class UnsupportedGrantType extends Error implements OAuth2Error {
 
   httpStatus = 400;
   errorCode = 'unsupported_grant_type';
@@ -115,7 +109,7 @@ export class UnsupportedGrantType extends Error implements OAuthError {
  * Internal Server Error HTTP status code cannot be returned to the client via
  * an HTTP redirect.)
  */
-export class ServerError extends Error implements OAuthError {
+export class ServerError extends Error implements OAuth2Error {
 
   httpStatus = 500;
   errorCode = 'server_error';
@@ -128,10 +122,9 @@ export class ServerError extends Error implements OAuthError {
  * needed because a 503 Service Unavailable HTTP status code cannot be returned
  * to the client via an HTTP redirect.)
  */
-export class TemporarilyUnavailable extends Error implements OAuthError {
+export class TemporarilyUnavailable extends Error implements OAuth2Error {
 
   httpStatus = 503;
   errorCode = 'temporarily_unavailable';
 
 }
-

--- a/src/oauth2/oauth2-error-handler.ts
+++ b/src/oauth2/oauth2-error-handler.ts
@@ -1,0 +1,30 @@
+import { Middleware } from '@curveball/core';
+import { isOAuth2Error } from './errors';
+
+const oauth2ErrorHandler: Middleware = async (ctx, next) => {
+
+  try {
+    await next();
+  } catch (err) {
+    if (isOAuth2Error(err)) {
+
+      /* eslint-disable-next-line no-console */
+      console.log(err);
+
+      ctx.status = err.httpStatus;
+      ctx.response.type = 'application/json';
+      ctx.response.body = {
+        error: err.errorCode,
+        error_description: err.message,
+      };
+
+    } else {
+      // Let someone else deal with it
+      throw err;
+    }
+
+  }
+
+};
+
+export default oauth2ErrorHandler;

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -31,13 +31,14 @@ import oauth2Metadata from './well-known/controller/oauth2-metadata';
 import clients from './oauth2-client/controller/collection';
 import client from './oauth2-client/controller/item';
 import clientNew from './oauth2-client/controller/new';
+import oauth2ErrorHandler from './oauth2/oauth2-error-handler';
 
 const routes = [
   router('/', home),
   router('/assets/:filename', blob),
 
-  router('/authorize', oauth2Authorize),
-  router('/token', oauth2Token),
+  router('/authorize', oauth2ErrorHandler, oauth2Authorize),
+  router('/token', oauth2ErrorHandler, oauth2Token),
   router('/revoke', oauth2Revoke),
 
   router('/create-user', createUser),


### PR DESCRIPTION
OAuth2 has its own error format, so needs its own error handling layer.
This existed before, but broke at some point, causing `undefined` error messages related to oauth2

This fixes error handling once more, as a new middleware.