### PR TITLE
one-time token bug fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "a12n-server",
+  "name": "@curveball/a12n-server",
   "version": "0.15.5",
   "lockfileVersion": 1,
   "requires": true,

--- a/src/one-time-token/controller.ts
+++ b/src/one-time-token/controller.ts
@@ -15,7 +15,7 @@ class OneTimeTokenController extends Controller {
       throw new Forbidden('Only users with the "admin" privilege can request for one time token');
     }
 
-    const user = await userService.findByIdentity(ctx.state.user.identity);
+    const user = await userService.findById(ctx.state.params.id);
 
     if (user.type !== 'user') {
       throw new Forbidden('One-time token may only be obtained for users');
@@ -23,7 +23,7 @@ class OneTimeTokenController extends Controller {
 
 
     const token = await createToken(user);
-    const url = resolve(process.env.PUBLIC_URI!, 'reset-password/token/' + token);
+    const url = resolve(process.env.PUBLIC_URI!, 'reset-password/token/' + token.token);
 
     ctx.response.body = hal.oneTimeToken(user, url, token);
 


### PR DESCRIPTION
fixing entire one-time token object was being passed in for token uri. 
also includes `ctx.state.user.identity` is the frontend user info instead of the new user we're trying to create.