### PR TITLE
Control CORS via settings.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -355,6 +355,21 @@
         }
       }
     },
+    "@curveball/cors": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@curveball/cors/-/cors-0.1.0.tgz",
+      "integrity": "sha512-A+kMqmkD3ghwssoSy8K7Fqz+qnee9yb//lvTjsKXzcNoPcTY/mdzDYzrL3wYTeA5b04dFqjGOz0blDUcVdicqw==",
+      "requires": {
+        "@curveball/http-errors": "^0.3.0"
+      },
+      "dependencies": {
+        "@curveball/http-errors": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/@curveball/http-errors/-/http-errors-0.3.0.tgz",
+          "integrity": "sha512-sCx/u8xFxlp/6tbhgCYXJDNLtUbxx3OYE5+jITyTiJhLCTopU5akF2eYlrwgxGtEi+tB8/JlCz0322YV4L6Daw=="
+        }
+      }
+    },
     "@curveball/http-errors": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/@curveball/http-errors/-/http-errors-0.4.0.tgz",

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "@curveball/browser": "^0.14.7",
     "@curveball/controller": "^0.3.0",
     "@curveball/core": "^0.16.2",
+    "@curveball/cors": "^0.1.0",
     "@curveball/http-errors": "^0.4.0",
     "@curveball/links": "^0.1.5",
     "@curveball/problem": "^0.3.0",

--- a/src/main-mw.ts
+++ b/src/main-mw.ts
@@ -1,12 +1,15 @@
 import bodyParser from '@curveball/bodyparser';
-import { invokeMiddlewares, Middleware } from '@curveball/core';
+import browser from '@curveball/browser';
+import cors from '@curveball/cors';
+import links from '@curveball/links';
 import problem from '@curveball/problem';
 import session from '@curveball/session';
 import { RedisStore } from '@curveball/session-redis';
-import browser from '@curveball/browser';
+import { invokeMiddlewares, Middleware } from '@curveball/core';
+
 import login from './middleware/login';
 import routes from './routes';
-import links from '@curveball/links';
+import { getSetting } from './server-settings';
 
 /**
  * The 'main middleware'.
@@ -21,7 +24,17 @@ export default function(): Middleware {
     throw new Error('PUBLIC_URI environment variable must be set.');
   }
 
-  const middlewares = [
+  const middlewares: Middleware[] = [];
+
+  const corsAllowOrigin = getSetting('cors.allowOrigin', undefined);
+
+  if (corsAllowOrigin) {
+    middlewares.push(cors({
+      allowOrigin: corsAllowOrigin
+    }));
+  }
+
+  middlewares.push(
     browser({
       title: 'a12n-server',
     }),
@@ -41,7 +54,7 @@ export default function(): Middleware {
     login(),
     bodyParser(),
     ...routes,
-  ];
+  );
 
   /**
    * This middleware contains all the a12n-server functionality.

--- a/src/server-settings.ts
+++ b/src/server-settings.ts
@@ -1,4 +1,5 @@
 type Settings = {
+  'cors.allowOrigin': string[],
   'oauth2.code.expiry': number,
   'oauth2.accessToken.expiry': number,
   'oauth2.refreshToken.expiry': number,


### PR DESCRIPTION
This PR lets a user control the 'Access-Control-Allow-Origin' CORS
header via server-settings.

By default this is locked down, but users may wish to (selectively) open
up the API to certain domains.