### PR TITLE
Change ADD NEW APP url from /app/new (404) → /create-user

### DIFF
--- a/src/app/formats/hal.ts
+++ b/src/app/formats/hal.ts
@@ -11,7 +11,7 @@ export function collection(apps: App[]): HalResource {
         href: app.href,
         title: app.nickname,
       })),
-      'create-form': { href: '/app/new', title: 'Add new App'},
+      'create-form': { href: '/create-user', title: 'Add new App'},
     },
     total: apps.length,
   };


### PR DESCRIPTION
The http://localhost:8531/app page has an **+ ADD NEW APP** button that leads to `/app/new` which currently doesn't exist, so it 404s.

Changed to `/create-user`, maybe the principal creation was meant to be split into user and app creation?
This fixes the 404 and gives the user access to creating a new app principal.

----
Is this a bug? LMK. 🔎🐞