### PR TITLE
A new systems for settings.

### DIFF
--- a/src/login/controller/login.ts
+++ b/src/login/controller/login.ts
@@ -74,7 +74,7 @@ class LoginController extends Controller {
       return;
     }
 
-    ctx.response.redirect(303, getSetting('login.defaultRedirect', '/'));
+    ctx.response.redirect(303, getSetting('login.defaultRedirect'));
 
   }
 

--- a/src/main-mw.ts
+++ b/src/main-mw.ts
@@ -28,7 +28,7 @@ export default function(): Middleware {
 
   const middlewares: Middleware[] = [];
 
-  const corsAllowOrigin = getSetting('cors.allowOrigin', null);
+  const corsAllowOrigin = getSetting('cors.allowOrigin');
 
   if (corsAllowOrigin) {
     middlewares.push(cors({

--- a/src/mfa/webauthn/controller/attestation.ts
+++ b/src/mfa/webauthn/controller/attestation.ts
@@ -14,7 +14,7 @@ class WebAuthnAttestationController extends Controller {
 
     const attestationOptions = generateAttestationOptions({
       rpName: getSetting('webauthn.serviceName'),
-      rpID: getSetting('webauthn.relyingPartyId', new URL(process.env.PUBLIC_URI!).host),
+      rpID: getSetting('webauthn.relyingPartyId') || new URL(process.env.PUBLIC_URI!).host,
       userID: user.id.toString(),
       userName: user.nickname,
       timeout: 60000,
@@ -50,8 +50,8 @@ class WebAuthnAttestationController extends Controller {
       verification = await verifyAttestationResponse({
         credential: body,
         expectedChallenge,
-        expectedOrigin: getSetting('webauthn.expectedOrigin', new URL(process.env.PUBLIC_URI!).origin),
-        expectedRPID: getSetting('webauthn.relyingPartyId', new URL(process.env.PUBLIC_URI!).host),
+        expectedOrigin: getSetting('webauthn.expectedOrigin') || new URL(process.env.PUBLIC_URI!).origin,
+        expectedRPID: getSetting('webauthn.relyingPartyId') || new URL(process.env.PUBLIC_URI!).host,
       });
     } catch (error) {
       /* eslint-disable-next-line no-console */

--- a/src/mfa/webauthn/controller/login.ts
+++ b/src/mfa/webauthn/controller/login.ts
@@ -45,8 +45,8 @@ class WebAuthnLoginRequestController extends Controller {
       verification = verifyAssertionResponse({
         credential: body,
         expectedChallenge,
-        expectedOrigin: getSetting('webauthn.expectedOrigin', new URL(process.env.PUBLIC_URI!).origin),
-        expectedRPID: getSetting('webauthn.relyingPartyId', new URL(process.env.PUBLIC_URI!).host),
+        expectedOrigin: getSetting('webauthn.expectedOrigin') || new URL(process.env.PUBLIC_URI!).origin,
+        expectedRPID: getSetting('webauthn.relyingPartyId') || new URL(process.env.PUBLIC_URI!).host,
         authenticator: {
           credentialID: authenticatorDevice.credentialID,
           counter: authenticatorDevice.counter,

--- a/src/oauth2/jwt.ts
+++ b/src/oauth2/jwt.ts
@@ -3,11 +3,12 @@ import { OAuth2Client } from '../oauth2-client/types';
 import { generateSecretToken } from '../crypto';
 import * as jwt from 'jsonwebtoken';
 import { resolve } from 'url';
+import { getSetting } from '../server-settings';
 
 type JwtAccessToken = {
 
   /**
-   * Issuer.
+   e Issuer.
    *
    * This will be URI pointing to the a12nserver instance
    */
@@ -56,7 +57,8 @@ type JwtAccessToken = {
 
 export async function generateJWTAccessToken(user: User|App, client: OAuth2Client, expiry: number, scopes: string[]): Promise<string> {
 
-  if (!process.env.JWT_PRIVATE_KEY) {
+  const jwtPrivateKey = getSetting('jwt.privateKey');
+  if (!jwtPrivateKey) {
     throw new Error('The JWT_PRIVATE_KEY environment variable must be set, and must be a RSA private key file (typically a .pem file)');
   }
 
@@ -66,7 +68,7 @@ export async function generateJWTAccessToken(user: User|App, client: OAuth2Clien
   // Some environment variable systems will convert the newline to a literal '\n'.
   // this is a safe operation, because the file should not contain any literal
   // backslashes.
-  const privateKey = process.env.JWT_PRIVATE_KEY.replace(/\\n/gm, '\n');
+  const privateKey = jwtPrivateKey.replace(/\\n/gm, '\n');
 
   const jwtBody: JwtAccessToken = {
     iss: origin,

--- a/src/oauth2/service.ts
+++ b/src/oauth2/service.ts
@@ -535,9 +535,9 @@ type TokenExpiry = {
 function getTokenExpiry(): TokenExpiry {
 
   return {
-    accessToken: getSetting('oauth2.accessToken.expiry', 600),
-    refreshToken: getSetting('oauth2.refreshToken.expiry', 3600 * 6),
-    code: getSetting('oauth2.code.expiry', 600),
+    accessToken: getSetting('oauth2.accessToken.expiry'),
+    refreshToken: getSetting('oauth2.refreshToken.expiry'),
+    code: getSetting('oauth2.code.expiry'),
   };
 
 }

--- a/src/oauth2/service.ts
+++ b/src/oauth2/service.ts
@@ -104,7 +104,7 @@ export async function generateTokenForUser(client: OAuth2Client, user: App | Use
 
   let accessToken: string;
 
-  if (process.env.JWT_PRIVATE_KEY) {
+  if (getSetting('jwt.privateKey')!==null) {
     accessToken = await generateJWTAccessToken(
       user,
       client,

--- a/src/reset-password/service.ts
+++ b/src/reset-password/service.ts
@@ -2,7 +2,7 @@ import * as nodemailer from 'nodemailer';
 import { render } from '../templates';
 import { User } from '../principal/types';
 import { createToken } from '../one-time-token/service';
-import { getSetting } from '../server-settings';
+import { requireSetting } from '../server-settings';
 
 /**
  * This function is for sending reset password email with validated token
@@ -13,15 +13,8 @@ import { getSetting } from '../server-settings';
  */
 export async function sendResetPasswordEmail(user: User) {
 
-  const smtpEmailFrom = getSetting('smtp.emailFrom');
-  const smtpUrl = getSetting('smtp.url');
-  if (!smtpEmailFrom) {
-    throw new Error('The \'smtp.emailFrom\' setting must be provided for email to work. You may set this via the SMTP_EMAIL_FROm environment variable or via the settings database.');
-  }
-
-  if (!smtpUrl) {
-    throw new Error('The \'smtp.url\' setting must be provided for email to work. You may provide this via the SMTP_URL environment variable or via the settings database.');
-  }
+  const smtpEmailFrom = requireSetting('smtp.emailFrom')!;
+  const smtpUrl = requireSetting('smtp.url')!;
 
   const transporter = nodemailer.createTransport(smtpUrl);
   const token = await createToken(user);

--- a/src/reset-password/service.ts
+++ b/src/reset-password/service.ts
@@ -2,7 +2,7 @@ import * as nodemailer from 'nodemailer';
 import { render } from '../templates';
 import { User } from '../principal/types';
 import { createToken } from '../one-time-token/service';
-
+import { getSetting } from '../server-settings';
 
 /**
  * This function is for sending reset password email with validated token
@@ -13,15 +13,17 @@ import { createToken } from '../one-time-token/service';
  */
 export async function sendResetPasswordEmail(user: User) {
 
-  if (!process.env.SMTP_EMAIL_FROM) {
-    throw new Error('The environment variable SMTP_EMAIL_FROM must be set');
+  const smtpEmailFrom = getSetting('smtp.emailFrom');
+  const smtpUrl = getSetting('smtp.url');
+  if (!smtpEmailFrom) {
+    throw new Error('The \'smtp.emailFrom\' setting must be provided for email to work. You may set this via the SMTP_EMAIL_FROm environment variable or via the settings database.');
   }
 
-  if (!process.env.SMTP_URL) {
-    throw new Error('The environment variable SMTP_URL must be set. Needs to contain "smtps://[Username]:[Password]@[Host]:[Port]"');
+  if (!smtpUrl) {
+    throw new Error('The \'smtp.url\' setting must be provided for email to work. You may provide this via the SMTP_URL environment variable or via the settings database.');
   }
 
-  const transporter = nodemailer.createTransport(process.env.SMTP_URL);
+  const transporter = nodemailer.createTransport(smtpUrl);
   const token = await createToken(user);
   const emailTemplate = render('emails/reset-password-email', {
     name: user.nickname,
@@ -31,7 +33,7 @@ export async function sendResetPasswordEmail(user: User) {
 
   // send mail with defined transport object
   const info = await transporter.sendMail({
-    from: process.env.SMTP_EMAIL_FROM, // sender address
+    from: smtpEmailFrom, // sender address
     to: user.identity.substring(7), // list of receivers
     subject: 'Password reset request', // Subject line
     html: emailTemplate

--- a/src/server-settings.ts
+++ b/src/server-settings.ts
@@ -48,19 +48,13 @@ const settingsRules: SettingsRules = {
   'smtp.url' : {
     description: 'The url to the SMTP server. See the node-mailer documentation for possible values',
     env: 'SMTP_URL',
-
-    // There's no reason this can't be in the DB, but code using this setting just needs to
-    // be changed to use the settings api.
-    fromDb: false,
+    fromDb: true,
     default: null,
   },
   'smtp.emailFrom' : {
     description: 'The "from" address that should be used for all outgoing emails',
     env: 'SMTP_EMAIL_FROM',
-
-    // There's no reason this can't be in the DB, but code using this setting just needs to
-    // be changed to use the settings api.
-    fromDb: false,
+    fromDb: true,
     default: null,
   },
 

--- a/src/server-settings.ts
+++ b/src/server-settings.ts
@@ -2,6 +2,8 @@ import db from './database';
 
 type Settings = {
   'login.defaultRedirect': string;
+  'registration.enabled': boolean;
+  'registration.mfa.enabled': boolean;
   'cors.allowOrigin': string[] | null;
 
   'smtp.url': null | string;
@@ -10,8 +12,9 @@ type Settings = {
   'oauth2.code.expiry': number;
   'oauth2.accessToken.expiry': number;
   'oauth2.refreshToken.expiry': number;
-  'registration.enabled': boolean;
-  'registration.mfa.enabled': boolean;
+
+  'jwt.privateKey': string | null,
+
   'totp': 'enabled' | 'required' | 'disabled';
   'totp.serviceName': string;
   'webauthn': 'enabled' | 'disabled' | 'required';
@@ -44,6 +47,16 @@ const settingsRules: SettingsRules = {
     fromDb: true,
     default: true,
   },
+  'registration.mfa.enabled': {
+    description: 'Whether MFA/2FA is enabled.',
+    fromDb: true,
+    default: true,
+  },
+  'cors.allowOrigin': {
+    description: 'List of allowed origins that may directly talk to the server. This should only ever be 1st party, trusted domains. By default CORS is not enabled',
+    fromDb: true,
+    default: null,
+  },
 
   'smtp.url' : {
     description: 'The url to the SMTP server. See the node-mailer documentation for possible values',
@@ -58,11 +71,7 @@ const settingsRules: SettingsRules = {
     default: null,
   },
 
-  'cors.allowOrigin': {
-    description: 'List of allowed origins that may directly talk to the server. This should only ever be 1st party, trusted domains. By default CORS is not enabled',
-    fromDb: true,
-    default: null,
-  },
+
 
   'oauth2.code.expiry': {
     description: 'The expiry time (in seconds) for the \'code\' from the oauth2 authorization code grant type',
@@ -83,10 +92,11 @@ const settingsRules: SettingsRules = {
     default: 3600*6,
   },
 
-  'registration.mfa.enabled': {
-    description: 'Whether MFA/2FA is enabled.',
-    fromDb: true,
-    default: true,
+  'jwt.privateKey': {
+    description: 'The RSA private key to sign JWT access tokens. Usually this value has the contents of a .pem file. If not set, JWT will be disabled',
+    env: 'JWT_PRIVATE_KEY',
+    fromDb: false,
+    default: null,
   },
 
   'totp': {

--- a/src/server-settings.ts
+++ b/src/server-settings.ts
@@ -138,6 +138,39 @@ export function getSetting<T extends keyof Settings>(setting: T): Settings[T] {
   return settingsCache[setting];
 
 }
+/**
+ * Retrieves the value of a single setting, by name.
+ *
+ * If the setting was not provided (null) this function will throw an exception.
+ */
+export function requireSetting<T extends keyof Settings>(setting: T): Settings[T] {
+
+  if (settingsCache === null) {
+    throw new Error('Settings have not been loaded. Call load() first');
+  }
+  const value = settingsCache[setting];
+  const info = settingsRules[setting];
+
+  if (value === null) {
+
+    let msg = `A value for the setting "${setting}" must be provided for this feature to work. `;
+    if (info.fromDb && info.env) {
+      msg+=`You should either set the "${setting}" setting in the database, or provide a value with the "${info.env}" environment variable.`;
+    } else if (info.fromDb) {
+      msg+=`You should set the "${setting}" setting in the database.`;
+    } else if (info.env) {
+      msg+=`You should provide a value with the "${info.env}" environment variable.`;
+    } else {
+      msg+'There is literally no way to actually do this, and this is a bug. DM me for a prize.';
+    }
+    throw msg;
+  }
+
+  return value;
+
+}
+
+
 
 /**
  * Loads or reloads settings from the database.

--- a/src/server-settings.ts
+++ b/src/server-settings.ts
@@ -1,3 +1,5 @@
+import db from './database';
+
 type Settings = {
   'cors.allowOrigin': string[] | null;
   'oauth2.code.expiry': number;
@@ -8,31 +10,114 @@ type Settings = {
   'totp': 'enabled' | 'required' | 'disabled';
   'totp.serviceName': string;
   'webauthn': 'enabled' | 'disabled' | 'required';
-  'webauthn.expectedOrigin': string;
-  'webauthn.relyingPartyId': string;
+  'webauthn.expectedOrigin': string | null;
+  'webauthn.relyingPartyId': string | null;
   'webauthn.serviceName': string;
   'login.defaultRedirect': string;
 }
 
-const settingsCache = new Map<string, any>();
-let settingsLoaded = false;
-import db from './database';
+type SettingsRules = {
+  [Setting in keyof Settings]: {
+    description: string;
+    env?: string;
+    fromDb: boolean;
+    isSecret?: boolean;
+    default: Settings[Setting];
+  }
+}
 
-export function getSetting<T extends keyof Settings>(setting: T, deflt?: Settings[T]): Settings[T] {
+const settingsRules: SettingsRules = {
 
-  if (!settingsLoaded) {
+  'login.defaultRedirect': {
+    description: 'This is the url that the user will be redirected to after the log in to a12nserver, and no other redirect_uri is provided by the application. It\'s a good idea to set this to your application URL',
+    fromDb: true,
+    default: '/',
+  },
+  'registration.enabled': {
+    description: 'Allow users to register new accounts. By default new accounts will be disabled and have no permissions.',
+    env: 'REGISTRATION_ENABLED',
+    fromDb: true,
+    default: true,
+  },
+
+  'cors.allowOrigin': {
+    description: 'List of allowed origins that may directly talk to the server. This should only ever be 1st party, trusted domains. By default CORS is not enabled',
+    fromDb: true,
+    default: null,
+  },
+
+  'oauth2.code.expiry': {
+    description: 'The expiry time (in seconds) for the \'code\' from the oauth2 authorization code grant type',
+    env: 'OAUTH2_CODE_EXPIRY',
+    fromDb: true,
+    default: 600,
+  },
+  'oauth2.accessToken.expiry': {
+    description: 'The expiry time (in seconds) for OAuth2 access token.',
+    env: 'OAUTH2_ACCESSTOKEN_EXPIRY',
+    fromDb: true,
+    default: 600
+  },
+  'oauth2.refreshToken.expiry': {
+    description: 'The expiry time (in seconds) for OAuth2 refresh tokens.',
+    env: 'OAUTH2_REFRESHTOKEN_EXPIRY',
+    fromDb: true,
+    default: 3600*6,
+  },
+
+  'registration.mfa.enabled': {
+    description: 'Whether MFA/2FA is enabled.',
+    fromDb: true,
+    default: true,
+  },
+
+  'totp': {
+    description: 'Whether TOTP is enabled. TOTP uses authenticator apps like Google Authenticator and Authy. This can be set to "enabled", "disabled", and "required"',
+    fromDb: true,
+    default: 'enabled',
+  },
+  'totp.serviceName': {
+    description: 'The name of the application that should show up in authenticator apps' ,
+    fromDb: true,
+    default: 'a12n-server API',
+  },
+
+  'webauthn': {
+    description: 'Whether webauthn is "enabled", "disabled" or "required".',
+    fromDb: true,
+    default: 'enabled',
+  },
+  'webauthn.serviceName': {
+    description: 'The service name that should appear in Webauthn dialogs.',
+    fromDb: true,
+    default: 'a12n-server',
+  },
+  'webauthn.expectedOrigin': {
+    description: 'The "origin" of this server. This must be set for webauthn to work',
+    fromDb: true,
+    default: null,
+  },
+  'webauthn.relyingPartyId': {
+    description: 'The origin of the application performing the login.',
+    fromDb: true,
+    default: null,
+  },
+
+};
+
+
+
+let settingsCache: Settings | null = null;
+
+/**
+ * Retrieves the value of a single setting, by name
+ */
+export function getSetting<T extends keyof Settings>(setting: T): Settings[T] {
+
+  if (settingsCache === null) {
     throw new Error('Settings have not been loaded. Call load() first');
   }
-
-  const value = settingsCache.get(setting);
-  if (value === undefined || value === null) {
-    if (deflt === undefined) {
-      throw new Error(`Setting ${setting} not found`);
-    }
-    return deflt;
-  } else {
-    return value;
-  }
+  return settingsCache[setting];
 
 }
 
@@ -41,12 +126,63 @@ export function getSetting<T extends keyof Settings>(setting: T, deflt?: Setting
  */
 export async function load(): Promise<void> {
 
+  // Load defaults first
+  const settings: Settings = Object.fromEntries(
+    Object.entries(settingsRules).map( ([settingName, settingInfo]) => {
+      return [
+        settingName,
+        settingInfo.default
+      ];
+    })
+  ) as Settings;
+
+  // Load database values next
   const query = 'SELECT setting, value FROM server_settings';
-  const result = await db.query(query);
+  const result: {setting: string; value: string}[] = (await db.query(query))[0];
 
-  for (const row of result[0]) {
-    settingsCache.set(row.setting, JSON.parse(row.value));
+  for (const row of result) {
+
+    if (!isValidSettingName(row.setting)) {
+      // eslint-disable-next-line no-console
+      console.warn('Unknown setting in database: %s. We ignored it.', row.setting);
+      continue;
+    }
+
+    if (!settingsRules[row.setting].fromDb) {
+      // eslint-disable-next-line no-console
+      console.warn('The setting %s may not be set from the database. We ignored it');
+      continue;
+    }
+
   }
-  settingsLoaded = true;
 
+  // Load settings from environment
+  for (const [settingName, settingInfo] of Object.entries(settingsRules)) {
+    if (!settingInfo.env) {
+      continue;
+    }
+    if (process.env[settingInfo.env]) {
+
+      const envValue = process.env[settingInfo.env]!;
+      let value;
+      switch(settingName) {
+        case 'registration.enabled': {
+          value = !['false','0','no'].includes(envValue);
+          break;
+        }
+        default :
+          value = envValue;
+      }
+
+      // A setting was passed via the environment. That setting wins!
+      (settings as any)[settingName] = value;
+    }
+  }
+
+  settingsCache = settings;
+}
+
+
+function isValidSettingName(name: string): name is keyof Settings {
+  return name in settingsRules;
 }

--- a/src/server-settings.ts
+++ b/src/server-settings.ts
@@ -13,7 +13,7 @@ type Settings = {
   'oauth2.accessToken.expiry': number;
   'oauth2.refreshToken.expiry': number;
 
-  'jwt.privateKey': string | null,
+  'jwt.privateKey': string | null;
 
   'totp': 'enabled' | 'required' | 'disabled';
   'totp.serviceName': string;

--- a/src/server-settings.ts
+++ b/src/server-settings.ts
@@ -1,7 +1,12 @@
 import db from './database';
 
 type Settings = {
+  'login.defaultRedirect': string;
   'cors.allowOrigin': string[] | null;
+
+  'smtp.url': null | string;
+  'smtp.emailFrom': null | string;
+
   'oauth2.code.expiry': number;
   'oauth2.accessToken.expiry': number;
   'oauth2.refreshToken.expiry': number;
@@ -13,7 +18,7 @@ type Settings = {
   'webauthn.expectedOrigin': string | null;
   'webauthn.relyingPartyId': string | null;
   'webauthn.serviceName': string;
-  'login.defaultRedirect': string;
+
 }
 
 type SettingsRules = {
@@ -38,6 +43,25 @@ const settingsRules: SettingsRules = {
     env: 'REGISTRATION_ENABLED',
     fromDb: true,
     default: true,
+  },
+
+  'smtp.url' : {
+    description: 'The url to the SMTP server. See the node-mailer documentation for possible values',
+    env: 'SMTP_URL',
+
+    // There's no reason this can't be in the DB, but code using this setting just needs to
+    // be changed to use the settings api.
+    fromDb: false,
+    default: null,
+  },
+  'smtp.emailFrom' : {
+    description: 'The "from" address that should be used for all outgoing emails',
+    env: 'SMTP_EMAIL_FROM',
+
+    // There's no reason this can't be in the DB, but code using this setting just needs to
+    // be changed to use the settings api.
+    fromDb: false,
+    default: null,
   },
 
   'cors.allowOrigin': {


### PR DESCRIPTION
I've been wanting to revamp settings for a bit. There's currently a few
different ways to provide settings, including environment variables and
via the database.

There is no central place where it's clear which setting exists, and
there's no good enough rules around where settings are set from
(environment or db).

Furthermore, if a setting is not set, we usually have a default. What
that default is, is determined by the 'caller', and also not centrally
which adds the risk that if different parts of the codebase use a
setting, there's nothing that enforces that that default is the same
everywhere.

Lastly, I want settings to bubble up in the interface so an admin can
easily see what settings are active (and where those settings came
from).

My intention with this PR is to solve all these problems, and so far
it's backwards compatible. This opens the door to some cool features,
and hopefully makes everything a little clearer.