### PR TITLE
Parse links *after* parsing the body

### DIFF
--- a/src/main-mw.ts
+++ b/src/main-mw.ts
@@ -44,7 +44,6 @@ export default function(): Middleware {
       ],
     }),
     problem(),
-    links(),
     session({
       store: process.env.REDIS_HOST ? new RedisStore({
         prefix: 'A12N-session',
@@ -58,6 +57,7 @@ export default function(): Middleware {
     }),
     login(),
     bodyParser(),
+    links(),
     validator({
       schemaPath: join(__dirname, '../schemas'),
       noLink: true,


### PR DESCRIPTION
If we parse links before the body, the links middleware can only get links from HTTP headers, and not HAL bodies.

This change fixes that.