### PR TITLE
Features/logo

### DIFF
--- a/assets/form.css
+++ b/assets/form.css
@@ -8,6 +8,18 @@ header {
   box-shadow: none;
   color: #1e88e5;
   position: relative;
+  height: unset !important;
+  flex-direction: column;
+  align-items: center;
+  gap: 2rem;
+}
+
+header .logo {
+  max-width: 25rem;
+}
+
+header .logo img {
+  width: 100%;
 }
 
 header h1 {

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -112,3 +112,27 @@ The SMTP_URL takes any format that that [Nodemailer](https://nodemailer.com/smtp
 
 
 [oauth2-jwt]: https://tools.ietf.org/html/draft-ietf-oauth-access-token-jwt-12
+
+
+Server Settings & Defaults
+--------------------------
+
+| Name                      | Type | Default value | Description |
+|:--------------------------|------|--------------:|-------------|
+| cors.allowOrigin          | Integer | NULL          | List of allowed origins that may directly talk to the server. This should only ever be 1st party, trusted domains. By default CORS is not enabled     
+| jwt.privateKey            | String  | NULL | The RSA private key to sign JWT access tokens. Usually this value has the contents of a .pem file. If not set, JWT will be disabled
+| login.defaultRedirect     | String  | `/`         | The url that the user will be redirected to after the log in to a12nserver, and no other redirect_uri is provided by the application. It's a good idea to set this to your application URL. 
+| logo_url                  | String  | NULL | The application logo to display on the a12nserver pages. If no logo url is provided, the application will show the Curveball logo by default. |
+| oauth2.code.expiry        | Integer | 600 (10 minutes) | The expiry time (in seconds) for the \'code\' from the oauth2 authorization code grant type |
+| oauth2.accessToken.expiry | Integer | 600 (10 minutes) | The expiry time (in seconds) for OAuth2 access token. |
+| oauth2.refreshToken.expiry| Integer | 3600 * 6 (6 hours) | The expiry time (in seconds) for OAuth2 refresh tokens. |
+| registration.enabled      | Boolean | true    | Allow users to register new accounts. By default new accounts will be disabled and have no permissions.|
+| registration.mf.enabled   | Boolean | true | Allow users to register new accounts. By default new accounts will be disabled and have no permissions.
+| smtp.url                  | String  | NULL  | The url to the SMTP server. See the node-mailer documentation for possible values
+| smtp.emailFrom            | String  | NULL | The "from" address that should be used for all outgoing emails
+| totp                      | String  | enabled | Whether TOTP is enabled. TOTP uses authenticator apps like Google Authenticator and Authy. This can be set to "enabled", "disabled", and "required"
+| totp.serviceName          | String  | `a12n-server API` | The name of the application that should show up in authenticator apps
+| webauthn                  | String  | enabled | Whether webauthn is "enabled", "disabled" or "required".'
+| webauthn.serviceName      | String  | `a12n-server` | The service name that should appear in Webauthn dialogs.
+| webauthn.expectedOrigin   | String  | NULL | The "origin" of this server. This must be set for webauthn to work
+| webauthn.relyingPartyId   | String  | NULL | The origin of the application performing the login.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -114,25 +114,8 @@ The SMTP_URL takes any format that that [Nodemailer](https://nodemailer.com/smtp
 [oauth2-jwt]: https://tools.ietf.org/html/draft-ietf-oauth-access-token-jwt-12
 
 
+
 Server Settings & Defaults
 --------------------------
 
-| Name                      | Type | Default value | Description |
-|:--------------------------|------|--------------:|-------------|
-| cors.allowOrigin          | Integer | NULL          | List of allowed origins that may directly talk to the server. This should only ever be 1st party, trusted domains. By default CORS is not enabled     
-| jwt.privateKey            | String  | NULL | The RSA private key to sign JWT access tokens. Usually this value has the contents of a .pem file. If not set, JWT will be disabled
-| login.defaultRedirect     | String  | `/`         | The url that the user will be redirected to after the log in to a12nserver, and no other redirect_uri is provided by the application. It's a good idea to set this to your application URL. 
-| logo_url                  | String  | NULL | The application logo to display on the a12nserver pages. If no logo url is provided, the application will show the Curveball logo by default. |
-| oauth2.code.expiry        | Integer | 600 (10 minutes) | The expiry time (in seconds) for the \'code\' from the oauth2 authorization code grant type |
-| oauth2.accessToken.expiry | Integer | 600 (10 minutes) | The expiry time (in seconds) for OAuth2 access token. |
-| oauth2.refreshToken.expiry| Integer | 3600 * 6 (6 hours) | The expiry time (in seconds) for OAuth2 refresh tokens. |
-| registration.enabled      | Boolean | true    | Allow users to register new accounts. By default new accounts will be disabled and have no permissions.|
-| registration.mf.enabled   | Boolean | true | Allow users to register new accounts. By default new accounts will be disabled and have no permissions.
-| smtp.url                  | String  | NULL  | The url to the SMTP server. See the node-mailer documentation for possible values
-| smtp.emailFrom            | String  | NULL | The "from" address that should be used for all outgoing emails
-| totp                      | String  | enabled | Whether TOTP is enabled. TOTP uses authenticator apps like Google Authenticator and Authy. This can be set to "enabled", "disabled", and "required"
-| totp.serviceName          | String  | `a12n-server API` | The name of the application that should show up in authenticator apps
-| webauthn                  | String  | enabled | Whether webauthn is "enabled", "disabled" or "required".'
-| webauthn.serviceName      | String  | `a12n-server` | The service name that should appear in Webauthn dialogs.
-| webauthn.expectedOrigin   | String  | NULL | The "origin" of this server. This must be set for webauthn to work
-| webauthn.relyingPartyId   | String  | NULL | The origin of the application performing the login.
+Read about configurable [settings and defaults here](https://github.com/curveball/a12n-server/tree/master/docs/server-settings).

--- a/docs/server-settings.md
+++ b/docs/server-settings.md
@@ -1,0 +1,28 @@
+Server Settings & Configuration
+-------------------------------
+
+The following table lists all configurable options for a12nserver. These can be changed in the `server_settings` table in your database.
+
+The value for each field is stored as a JSON string. This means that in order to store ``'null'``, you need the literal string ``'null'``.  \
+To store a string, it needs to be surrounded by double-quotes. For example, a legal value for the `smpt.emailFrom` field might be `"info@example.org"`.
+
+
+| Name                      | Type | Default value | Description |
+|:--------------------------|------|--------------:|-------------|
+| cors.allowOrigin          | Integer | `null`          | List of allowed origins that may directly talk to the server. This should only ever be 1st party, trusted domains. By default CORS is not enabled     
+| jwt.privateKey            | String  | `null` | The RSA private key to sign JWT access tokens. Usually this value has the contents of a .pem file. If not set, JWT will be disabled
+| login.defaultRedirect     | String  | `/`         | The url that the user will be redirected to after the log in to a12nserver, and no other redirect_uri is provided by the application. It's a good idea to set this to your application URL. 
+| logo_url                  | String  | `null` | The application logo to display on the a12nserver pages. If no logo url is provided, the application will show the Curveball logo by default. |
+| oauth2.code.expiry        | Integer | `600` | The expiry time (in seconds) for the \'code\' from the oauth2 authorization code grant type |
+| oauth2.accessToken.expiry | Integer | `600` | The expiry time (in seconds) for OAuth2 access token. |
+| oauth2.refreshToken.expiry| Integer | `3600 * 6` | The expiry time (in seconds) for OAuth2 refresh tokens. |
+| registration.enabled      | Boolean | `true`    | Allow users to register new accounts. By default new accounts will be disabled and have no permissions.|
+| registration.mf.enabled   | Boolean | `true` | Allow users to register new accounts. By default new accounts will be disabled and have no permissions.
+| smtp.url                  | String  | `null`  | The url to the SMTP server. See the node-mailer documentation for possible values
+| smtp.emailFrom            | String  | `null` | The "from" address that should be used for all outgoing emails
+| totp                      | String  | `enabled` | Whether TOTP is enabled. TOTP uses authenticator apps like Google Authenticator and Authy. This can be set to "enabled", "disabled", and "required"
+| totp.serviceName          | String  | `a12n-server API` | The name of the application that should show up in authenticator apps
+| webauthn                  | String  | `enabled` | Whether webauthn is "enabled", "disabled" or "required".'
+| webauthn.serviceName      | String  | `a12n-server` | The service name that should appear in Webauthn dialogs.
+| webauthn.expectedOrigin   | String  | `null` | The "origin" of this server. This must be set for webauthn to work
+| webauthn.relyingPartyId   | String  | `null` | The origin of the application performing the login.

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "@curveball/bodyparser": "^0.4.14",
     "@curveball/browser": "^0.16.0",
     "@curveball/controller": "^0.3.0",
-    "@curveball/core": "^0.16.2",
+    "@curveball/core": "^0.16.3",
     "@curveball/cors": "^0.1.0",
     "@curveball/http-errors": "^0.4.0",
     "@curveball/links": "^0.1.5",

--- a/src/login/controller/login.ts
+++ b/src/login/controller/login.ts
@@ -30,8 +30,7 @@ class LoginController extends Controller {
       {
         continue: ctx.query.continue,
       },
-      await getSetting('registration.enabled'),
-      await getSetting('logo_url')
+      getSetting('registration.enabled')
     );
 
   }

--- a/src/login/controller/login.ts
+++ b/src/login/controller/login.ts
@@ -31,6 +31,7 @@ class LoginController extends Controller {
         continue: ctx.query.continue,
       },
       await getSetting('registration.enabled'),
+      await getSetting('logo_url')
     );
 
   }

--- a/src/login/formats/html.ts
+++ b/src/login/formats/html.ts
@@ -1,7 +1,7 @@
 import { render } from '../../templates';
 type KeyValue = { [key: string]: string };
 
-export function loginForm(msg: string, error: string, hiddenFields: KeyValue, registrationEnabled: boolean): string {
+export function loginForm(msg: string, error: string, hiddenFields: KeyValue, registrationEnabled: boolean, logoUrl:string | null): string {
   return render('login', {
     title: 'Login',
     msg: msg,
@@ -9,6 +9,7 @@ export function loginForm(msg: string, error: string, hiddenFields: KeyValue, re
     hiddenFields: hiddenFields,
     action: '/login',
     registrationEnabled,
+    logoUrl
   });
 
 }

--- a/src/login/formats/html.ts
+++ b/src/login/formats/html.ts
@@ -1,15 +1,14 @@
 import { render } from '../../templates';
 type KeyValue = { [key: string]: string };
 
-export function loginForm(msg: string, error: string, hiddenFields: KeyValue, registrationEnabled: boolean, logoUrl:string | null): string {
+export function loginForm(msg: string, error: string, hiddenFields: KeyValue, registrationEnabled: boolean): string {
   return render('login', {
     title: 'Login',
     msg: msg,
     error: error,
     hiddenFields: hiddenFields,
     action: '/login',
-    registrationEnabled,
-    logoUrl
+    registrationEnabled
   });
 
 }

--- a/src/server-settings.ts
+++ b/src/server-settings.ts
@@ -21,6 +21,7 @@ type Settings = {
   'webauthn.expectedOrigin': string | null;
   'webauthn.relyingPartyId': string | null;
   'webauthn.serviceName': string;
+  'logo_url': string | null;
 
 }
 
@@ -35,7 +36,11 @@ type SettingsRules = {
 }
 
 const settingsRules: SettingsRules = {
-
+  'logo_url' : {
+    description: 'The application logo to display on the a12nserver pages',
+    fromDb: true,
+    default: '' //curveball logo
+  },
   'login.defaultRedirect': {
     description: 'This is the url that the user will be redirected to after the log in to a12nserver, and no other redirect_uri is provided by the application. It\'s a good idea to set this to your application URL',
     fromDb: true,

--- a/src/server-settings.ts
+++ b/src/server-settings.ts
@@ -39,7 +39,7 @@ const settingsRules: SettingsRules = {
   'logo_url' : {
     description: 'The application logo to display on the a12nserver pages',
     fromDb: true,
-    default: '/_hal-browser/assets/curveball.svg' // curveball logo, should be replaced with word mark logo (see https://github.com/curveball/browser/pull/119)
+    default: '/_hal-browser/assets/curveball-logo-wordmark.svg'
   },
   'login.defaultRedirect': {
     description: 'This is the url that the user will be redirected to after the log in to a12nserver, and no other redirect_uri is provided by the application. It\'s a good idea to set this to your application URL',

--- a/src/server-settings.ts
+++ b/src/server-settings.ts
@@ -21,7 +21,7 @@ type Settings = {
   'webauthn.expectedOrigin': string | null;
   'webauthn.relyingPartyId': string | null;
   'webauthn.serviceName': string;
-  'logo_url': string | null;
+  'logo_url': string;
 
 }
 
@@ -39,7 +39,7 @@ const settingsRules: SettingsRules = {
   'logo_url' : {
     description: 'The application logo to display on the a12nserver pages',
     fromDb: true,
-    default: '' //curveball logo
+    default: '/_hal-browser/assets/curveball.svg' // curveball logo, should be replaced with word mark logo (see https://github.com/curveball/browser/pull/119)
   },
   'login.defaultRedirect': {
     description: 'This is the url that the user will be redirected to after the log in to a12nserver, and no other redirect_uri is provided by the application. It\'s a good idea to set this to your application URL',

--- a/src/templates.ts
+++ b/src/templates.ts
@@ -1,5 +1,6 @@
 import * as fs from 'fs';
 import * as handlebars from 'handlebars';
+import { getSetting } from './server-settings';
 
 type Params = {
   [key: string]: any;
@@ -16,10 +17,12 @@ export function render(name: string, params?: Params): string {
   const newParams = {};
   Object.assign(newParams, params, {
     appName: 'Auth API',
+    logoUrl: getSetting('logo_url')
   });
+
   return layoutTemplate({
-    ...params,
-    body: pageTemplate(params)
+    ...newParams,
+    body: pageTemplate(newParams)
   });
 
 }

--- a/templates/layout.hbs
+++ b/templates/layout.hbs
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>{{ appName }}</title>
+    <title>{{ appName }} </title>
     <meta charset="utf-8" />
     <link rel="stylesheet" href="/_hal-browser/assets/themes/lfo/main.css" type="text/css" />
     <link rel="stylesheet" href="/assets/form.css" type="text/css" />
@@ -9,6 +9,10 @@
   <body>
 
     <header>
+      <div class="logo">
+        <img src="{{ logoUrl }}" alt="{{ appName }}" />
+      </div>
+
       <h1>{{ title }}</h1>
     </header>
     {{{ body }}}

--- a/templates/login.hbs
+++ b/templates/login.hbs
@@ -1,4 +1,17 @@
 <form action="{{ action }}" method="post">
+
+  {{#if logoUrl}}
+    <!-- show app logo -->
+    <fieldset><img src={{logoUrl}} style="max-width: 100%"/></fieldset>
+    {{#else}}
+    
+    <!-- show curveball logo -->
+    <fieldset style="background: #1e88e5;">
+      <img src="https://curveballjs.org/assets/images/logo.svg" style="max-width: 100%"/>
+    </fieldset>
+    {{/else}}
+  {{/if}}
+
   {{# if msg}}
   <div class="msg info">{{ msg }}</div>
   {{/if}}

--- a/templates/login.hbs
+++ b/templates/login.hbs
@@ -1,17 +1,5 @@
 <form action="{{ action }}" method="post">
-
-  {{#if logoUrl}}
-    <!-- show app logo -->
-    <fieldset><img src={{logoUrl}} style="max-width: 100%"/></fieldset>
-    {{#else}}
-    
-    <!-- show curveball logo -->
-    <fieldset style="background: #1e88e5;">
-      <img src="https://curveballjs.org/assets/images/logo.svg" style="max-width: 100%"/>
-    </fieldset>
-    {{/else}}
-  {{/if}}
-
+  
   {{# if msg}}
   <div class="msg info">{{ msg }}</div>
   {{/if}}


### PR DESCRIPTION
Adds a logo to the `/login` page. 
Logo is a link in the `server_settings` table, or if absent there, the Curveball logo (hardcoded to curveballjs.org). 

The PR is still incomplete, _I think_ the logo should be added to all pages, but up for suggestions. 
I tried to looking into that but I'm not sure how to add the prop to the main layout.hbs template, @evert do you have some suggestions ?

Also note how the parameter is typed in `formats/html.ts`, not sure if that\s the best way to do it, the other option was to have `await getSetting('logo_url') || ''` in the controller, which seems ugly.