### PR TITLE
.env.defaults improvements

### DIFF
--- a/.env.defaults
+++ b/.env.defaults
@@ -1,8 +1,57 @@
+# TCP port to run on 
 PORT=8531
-MYSQL_HOST=127.0.0.1
-MYSQL_PASSWORD=password
-MYSQL_USER=a12nserver
-MYSQL_DATABASE=a12nserver
-SMTP_URL=""
-SMTP_EMAIL_FROM=''
+
+# Public URL. This must be the URL that users will use to access a12nserver.
+# If this is not provided or incorrect, this will result in the server not
+# functioning correctly.
 PUBLIC_URI="http://localhost:8531/"
+
+# Database settings
+# a12n-server supports multiple databases servers.
+# to configure it, use one of the following sections
+
+
+# MySQL database settings
+
+# MYSQL_HOST=127.0.0.1
+# MYSQL_PASSWORD=password
+# MYSQL_USER=a12nserver
+# MYSQL_DATABASE=a12nserver
+
+# Postgres database settings
+#
+# PG_HOST=127.0.0.1
+# PG_PASSWORD='password
+# PG_USER=a12nserver
+# PG_DATABASE=a12nserver
+
+
+# Email settings
+#
+# These settings are optional, but if they are not provided certain features
+# such as 'lost password' will not work.
+
+# Should be in the format smtp://username:password@smtp.example
+SMTP_URL=
+
+# Email address that should be used as the FROM address
+SMTP_EMAIL_FROM=
+
+
+
+# Allow new users to register?
+REGISTRATION_ENABLED=1
+
+
+# OAuth2 settings
+#
+# All of these settings have reasonable defaults, and can also be set in the
+# database.
+
+# OAUTH2_ACCESSTOKEN_EXPIRY=600
+# OAUTH2_REFRESHTOKEN_EXPIRY=21600
+# OAUTH2_CODE_EXPIRY=600
+
+# If set, the server will generate JWT for access tokens. This must be a RSA
+# private key
+# JWT_PRIVATE_KEY=

--- a/.env.defaults
+++ b/.env.defaults
@@ -37,10 +37,16 @@ SMTP_URL=
 # Email address that should be used as the FROM address
 SMTP_EMAIL_FROM=
 
-
-
 # Allow new users to register?
 REGISTRATION_ENABLED=1
+
+
+# Redis settings
+#
+# Using Redis is a must if you paln on running multiple load-balanced
+# instances of a12n-server
+# REDIS_HOST=
+# REDIS=PORT=6379
 
 
 # OAuth2 settings

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+0.20.0 (????-??-??)
+-------------------
+
+* `.env.defaults` is no longer automatically loaded. The file still exists but
+  its only purpose is to provide a template for developers to copy to `.env`.
+
+
 0.19.12 (2022-01-12)
 --------------------
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,34 +1,46 @@
 Getting started
 ===============
 
-To set up a new a12n-server from scratch, start by obtaining the following
-prerequisites:
+To set up this server in your development environment, the following must be
+installed:
 
 1. NodeJS (version 14 or higher) and `npm`.
 2. `git`.
-3. MySQL (For Mac: install via ).
-    - For Mac: easy install Homebrew [MySQL package](https://formulae.brew.sh/formula/mysql)
-      via [Homebrew](https://brew.sh/).
-    - For Linux: `apt install mysql-server`
-4. Optional: A working [Docker][1] installation. The server can also be run
-   straight from the cli.
+3. MySQL, PostgreSQL or Sqlite. The latter should only be used for development
+   environments.
 
-After all of these prerequisites are acquired, run:
+
+If you are deploying in production, we recommend the
+[official docker images][1].
+
+
+Getting the development environment up and running
+--------------------------------------------------
+
+Get the source:
 
 ```sh
-git clone git@github.com:evert/a12n-server.git
+git clone git@github.com:curveball/a12n-server.git
 cd a12n-server
 npm install
 ```
 
-If using Docker, finish off with:
+Configuring the server
+----------------------
+
+Copy `.env.defaults` to `.env` and open the file up in your editor.
 
 ```sh
-make docker-build
+cp .env.defaults .env
 ```
 
-MySQL setup
------------
+In your editor, go through the file and configure it so it makes sense to you.
+
+For the database, pick the section of your choice. If your database is setup
+correctly and a12nserver has access to it, it will automatically connect to it
+on start and build the database schema.
+
+### MySQL setup
 
 After you have MySQL up and running, create new empty database (/schema) & user for `a12n-server`. Replace 'your_password' with a proper user password of your creation.
 
@@ -39,53 +51,28 @@ mysql> GRANT SELECT, INSERT, UPDATE, DELETE, ALTER, CREATE, DROP ON a12nserver.*
 mysql> FLUSH PRIVILEGES;
 ```
 
+### Postgres setup
+
+TODO
+
+
+### Sqlite setup
+
+TODO
+
+
 Running the server
 ------------------
 
-Docker:
-
-```sh
-export MYSQL_PASSWORD=your_password
-export MYSQL_USER=a12nserver
-export MYSQL_DATABASE=a12nserver
-docker run -it --rm -p 127.0.0.1:8531:8531 --name a12n-server-01 a12n-server
-```
-
-If you are running a12nserver outside of docker, the easiest way to change environment variables is to create a `.env` file in the a12n-server project root, and specify the following settings.
-
-```sh
-PORT=8531
-MYSQL_HOST=127.0.0.1
-MYSQL_PASSWORD=your_password
-MYSQL_USER=a12nserver
-MYSQL_DATABASE=a12nserver
-PUBLIC_URI="http://localhost:8531/"
-```
-
-Note: There are several environment variables available to modify the a12n-server
-behavior. See the table below.
-
-|                           Name | Required? |               Default | Description                                                   |
-|:------------------------------ |----------:|----------------------:|---------------------------------------------------------------|
-| MYSQL_HOST                     |           |             127.0.0.1 | IP address to connect to where the `mysql-schema` was applied |
-| MYSQL_USER                     |       Yes |                       | User to connect to MySQL with                                 |
-| MYSQL_PASSWORD                 |       Yes |                       | Password to authenticate to MySQL                             |
-| MYSQL_DATABASE                 |       Yes |                       | Database where the `mysql-schema` was applied                 |
-| MYSQL_PORT                     |       No  |                  3306 | The port of MySQL                                             |
-| MYSQL_INSTANCE_CONNECTION_NAME |           |                       |                                                               |
-| PUBLIC_URI                     |           | http://localhost:8531 |                                                               |
-| PORT                           |           |                  8531 | Port to host the API on.                                      |
-| SMTP_URL                       |           |                       | See below section, [Email](#Email)                      |
-| SMTP_EMAIL_FROM                |           |                       | See below section, [Email](#Email)                      |
-| REDIS_HOST                     |           |                       | When specified, use Redis as a session storage. Required for running the server on multiple hosts.
-| REDIS_PORT                     |           |                  6379 | Set tcp port for Redis
-| JWT_PRIVATE_KEY                | No        |                       | When set, a12nserver will generate JWT OAuth2 Access tokens as specified in [draft-ietf-oauth-access-token-jwt][oauth2-jwt]. If this is not set, opaque strings will be used |
-
-To start the server, we use `make`. Simply execute
+After all that, all you have to do is run:
 
 ```sh
 make start
 ```
+
+If you are developing a12nserver, you might prefer `make start-dev` which
+automatically restarts the server when you make a chance.
+
 
 Creating the first user
 -----------------------
@@ -93,23 +80,5 @@ Creating the first user
 After installation, you can open the server via `https://localhost:8531/`,
 which will prompt you to create your first admin user.
 
-Email
------
 
-To use any email related feature, such as 'reset password', the following environment variables are also required.
-
-```sh
-export SMTP_URL="smtps://[username]:[password]@[host]:[port]/"
-export SMTP_EMAIL_FROM='"[Name]" <[Username]@example.org>'
-```
-The SMTP_URL takes any format that that [Nodemailer](https://nodemailer.com/smtp/) takes.
-
-
-[oauth2-jwt]: https://tools.ietf.org/html/draft-ietf-oauth-access-token-jwt-12
-
-
-
-Server Settings & Defaults
---------------------------
-
-Read about configurable [settings and defaults here](https://github.com/curveball/a12n-server/tree/master/docs/server-settings).
+[1]: https://github.com/curveball/a12n-server/pkgs/container/a12n-server%2Fa12nserver

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,6 @@
         "bcrypt": "^5.0.1",
         "csv-stringify": "^6.0.5",
         "dotenv": "^16.0.0",
-        "dotenv-defaults": "^5.0.0",
         "geoip-lite": "^1.4.2",
         "handlebars": "^4.7.7",
         "jsonwebtoken": "^8.5.1",
@@ -2182,22 +2181,6 @@
       "version": "16.0.0",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.0.tgz",
       "integrity": "sha512-qD9WU0MPM4SWLPJy/r2Be+2WgQj8plChsyrCNQzW/0WjvcJQiKQJ9mH3ZgB3fxbUUxgc/11ZJ0Fi5KiimWGz2Q==",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/dotenv-defaults": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/dotenv-defaults/-/dotenv-defaults-5.0.0.tgz",
-      "integrity": "sha512-YnSVn9UP3j1njjalwrjOSlFkcT9b06BYSy5RqK1gI7bD+iezY7a1GOgJ+M4Vcs4A5RcE/ZcK1bYUAzIjUNqAzA==",
-      "dependencies": {
-        "dotenv": "^14.0.0"
-      }
-    },
-    "node_modules/dotenv-defaults/node_modules/dotenv": {
-      "version": "14.3.2",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-14.3.2.tgz",
-      "integrity": "sha512-vwEppIphpFdvaMCaHfCEv9IgwcxMljMw2TnAQBB4VWPvzXQLTb82jwmdOKzlEVUL3gNFT4l4TPKO+Bn+sqcrVQ==",
       "engines": {
         "node": ">=12"
       }
@@ -7807,21 +7790,6 @@
       "version": "16.0.0",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.0.tgz",
       "integrity": "sha512-qD9WU0MPM4SWLPJy/r2Be+2WgQj8plChsyrCNQzW/0WjvcJQiKQJ9mH3ZgB3fxbUUxgc/11ZJ0Fi5KiimWGz2Q=="
-    },
-    "dotenv-defaults": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/dotenv-defaults/-/dotenv-defaults-5.0.0.tgz",
-      "integrity": "sha512-YnSVn9UP3j1njjalwrjOSlFkcT9b06BYSy5RqK1gI7bD+iezY7a1GOgJ+M4Vcs4A5RcE/ZcK1bYUAzIjUNqAzA==",
-      "requires": {
-        "dotenv": "^14.0.0"
-      },
-      "dependencies": {
-        "dotenv": {
-          "version": "14.3.2",
-          "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-14.3.2.tgz",
-          "integrity": "sha512-vwEppIphpFdvaMCaHfCEv9IgwcxMljMw2TnAQBB4VWPvzXQLTb82jwmdOKzlEVUL3gNFT4l4TPKO+Bn+sqcrVQ=="
-        }
-      }
     },
     "duplexer": {
       "version": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -90,7 +90,6 @@
     "bcrypt": "^5.0.1",
     "csv-stringify": "^6.0.5",
     "dotenv": "^16.0.0",
-    "dotenv-defaults": "^5.0.0",
     "geoip-lite": "^1.4.2",
     "handlebars": "^4.7.7",
     "jsonwebtoken": "^8.5.1",

--- a/src/app.ts
+++ b/src/app.ts
@@ -13,9 +13,6 @@ console.info('⚾ %s %s', pkgInfo.name, pkgInfo.version);
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 require('dotenv').config();
 
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-require('dotenv-defaults').config();
-
 const port = process.env.PORT ? parseInt(process.env.PORT, 10) :  8531;
 if (!process.env.PUBLIC_URI) {
   process.env.PUBLIC_URI = 'http://localhost:' + port + '/';


### PR DESCRIPTION
This PR makes a number of changes:

* No longer auto-load `.env.defaults`. Instead, we require users to copy the file. This is way more common for applications such as this, so I felt it was worth making this change.
* Simplify the getting started doc
* 