### PR TITLE
Some changes to settings

### DIFF
--- a/.env.defaults
+++ b/.env.defaults
@@ -1,4 +1,4 @@
-# TCP port to run on 
+# TCP port to run on
 PORT=8531
 
 # Public URL. This must be the URL that users will use to access a12nserver.

--- a/.env.defaults
+++ b/.env.defaults
@@ -13,18 +13,23 @@ PUBLIC_URI="http://localhost:8531/"
 
 # MySQL database settings
 
-# MYSQL_HOST=127.0.0.1
-# MYSQL_PASSWORD=password
-# MYSQL_USER=a12nserver
-# MYSQL_DATABASE=a12nserver
+# DB_DRIVER=mysql
+# DB_HOST=127.0.0.1
+# DB_PASSWORD=password
+# DB_USER=a12nserver
+# DB_DATABASE=a12nserver
 
 # Postgres database settings
 #
-# PG_HOST=127.0.0.1
-# PG_PASSWORD='password
-# PG_USER=a12nserver
-# PG_DATABASE=a12nserver
+# DB_DRIVER=postgres
+# DB_HOST=127.0.0.1
+# DB_PASSWORD='password
+# DB_USER=a12nserver
+# DB_DATABASE=a12nserver
 
+# Sqlite database settings
+# DB_DRIVER=sqlite3
+# DB_FILENAME=a12nserver.sqlite3
 
 # Email settings
 #

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Features
   * WebauthN / Yubikeys
 * A simple, flat, permission model.
 * Registration, lost password.
+* [`secret-token:` URI scheme][6]
 
 
 Documentation
@@ -54,3 +55,4 @@ developed.
 [3]: https://tools.ietf.org/html/rfc7636 "Proof Key for Code Exchange by OAuth Public Clients"
 [4]: https://auth0.com/docs/secure/tokens/json-web-tokens/json-web-key-sets
 [5]: https://datatracker.ietf.org/doc/html/rfc7009
+[6]: https://datatracker.ietf.org/doc/html/rfc8959

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,8 @@ Changelog
 
 * Support for the `/.well-known/jwks.json` endpoint, allowing clients to
   discover JWT public keys.
+* OAuth2 secrets are now prefixed with the `secret-token:` uri scheme,
+  allowing github and other systems to detect possible commits of secret data.
 * `.env.defaults` is no longer automatically loaded. The file still exists but
   its only purpose is to provide a template for developers to copy to `.env`.
 

--- a/changelog.md
+++ b/changelog.md
@@ -4,10 +4,18 @@ Changelog
 0.20.0 (????-??-??)
 -------------------
 
+* Now requires Node 16.
+* Postgres support! (@mihok)
+* Experimental sqlite support.
+* Migrated all database access to Knex.
+* Database migrations are now automatically run on startup, making upgrades a
+  log easier.
 * Support for the `/.well-known/jwks.json` endpoint, allowing clients to
   discover JWT public keys.
 * OAuth2 secrets are now prefixed with the `secret-token:` uri scheme,
   allowing github and other systems to detect possible commits of secret data.
+* A new settings panel for admins, allowing admins to see exactly which
+  settings have been applied. This is currently read-only.
 * `.env.defaults` is no longer automatically loaded. The file still exists but
   its only purpose is to provide a template for developers to copy to `.env`.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -6,8 +6,7 @@ installed:
 
 1. NodeJS (version 14 or higher) and `npm`.
 2. `git`.
-3. MySQL, PostgreSQL or Sqlite. The latter should only be used for development
-   environments.
+3. MySQL, PostgreSQL or SQLite. SQLite is not recommended for production.
 
 
 If you are deploying in production, we recommend the

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@curveball/accesslog": "^0.2.1",
         "@curveball/bodyparser": "^0.4.14",
-        "@curveball/browser": "^0.17.3",
+        "@curveball/browser": "^0.17.4",
         "@curveball/controller": "^0.3.0",
         "@curveball/core": "^0.18.0-alpha.0",
         "@curveball/cors": "^0.1.0",
@@ -61,6 +61,45 @@
         "ts-node": "^10.0.0",
         "tsc-watch": "^4.2.9",
         "typescript": "^4.5.4"
+      }
+    },
+    "../browser": {
+      "name": "@curveball/browser",
+      "version": "0.17.4",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "@curveball/static": "^0.2.0",
+        "csv-parse": "^4.15.3",
+        "highlight.js": "^11.2.0",
+        "ketting": "^7.3.0",
+        "markdown-it": "^12.3.2",
+        "node-fetch": "^2.6.7",
+        "react": "^17.0.1",
+        "react-dom": "^17.0.1"
+      },
+      "devDependencies": {
+        "@curveball/core": "^0.18.0",
+        "@types/chai": "^4.2.15",
+        "@types/markdown-it": "^12.0.1",
+        "@types/mocha": "^9.0.0",
+        "@types/node": "^12.20.4",
+        "@types/node-fetch": "^2.6.1",
+        "@types/react": "^17.0.3",
+        "@types/react-dom": "^17.0.1",
+        "@typescript-eslint/eslint-plugin": "^5.9.1",
+        "@typescript-eslint/parser": "^5.9.1",
+        "chai": "^4.3.3",
+        "eslint": "^8.1.0",
+        "html-form-enhancer": "^0.1.9",
+        "jsdom": "^19.0.0",
+        "mocha": "^9.1.1",
+        "nyc": "^15.1.0",
+        "ts-node": "^10.0.0",
+        "typescript": "^4.2.3"
+      },
+      "peerDependencies": {
+        "@curveball/core": ">=0.14 <1"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -504,9 +543,9 @@
       }
     },
     "node_modules/@curveball/browser": {
-      "version": "0.17.3",
-      "resolved": "https://registry.npmjs.org/@curveball/browser/-/browser-0.17.3.tgz",
-      "integrity": "sha512-ZrPO21AxPzTV2zsBedugoT/5eWAfdGG0jFNHCdftRQ+Pcs2acxGDFVwRFOCAozO0yb3T+gSZyD6LSgMYV5G7oQ==",
+      "version": "0.17.4",
+      "resolved": "https://registry.npmjs.org/@curveball/browser/-/browser-0.17.4.tgz",
+      "integrity": "sha512-VG0B4e6C8q2vn+Z9a1N98ovxTIdk3jC6me/nLX8dryBn1SgkNjxwH2q7uqwl2mIUOV6seoqD9osLj2O0QnelCQ==",
       "dependencies": {
         "@curveball/static": "^0.2.0",
         "csv-parse": "^4.15.3",
@@ -521,17 +560,6 @@
         "@curveball/core": ">=0.14 <1"
       }
     },
-    "node_modules/@curveball/browser/node_modules/@curveball/static": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@curveball/static/-/static-0.2.1.tgz",
-      "integrity": "sha512-6h2P0/CXzOItxHdjGZtpv6yBpshqcLMrejo6vEkEkQR0WCu8BBqNcjD/a7wuy38FYLq0J/QXMidvaFL4jXHh7Q==",
-      "dependencies": {
-        "mime-types": "^2.1.29"
-      },
-      "peerDependencies": {
-        "@curveball/core": ">=0.16 <1"
-      }
-    },
     "node_modules/@curveball/controller": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/@curveball/controller/-/controller-0.3.2.tgz",
@@ -541,9 +569,9 @@
       }
     },
     "node_modules/@curveball/core": {
-      "version": "0.18.0-alpha.0",
-      "resolved": "https://registry.npmjs.org/@curveball/core/-/core-0.18.0-alpha.0.tgz",
-      "integrity": "sha512-DANa7FAL1Va3kjpe7KXB+x9c5JwjL6OoMlkyeItgokGiV99vH9xjQzNZOcmFlveUTCp9p0biCg3d9r7WlR1V6A==",
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/@curveball/core/-/core-0.18.0.tgz",
+      "integrity": "sha512-8V0SSKGm1yWWXi9ATtxIneRKnhHg2gffyx0PEbJi2dUPE5xBEl/kbxFliiND9Uf6FjUCbDRuip/N9NNZakVf9Q==",
       "dependencies": {
         "@curveball/http-errors": "^0.4.0",
         "@types/ws": "^8.5.3",
@@ -621,6 +649,17 @@
       "dependencies": {
         "cookie": "^0.4.1",
         "redis": "^3.0.2"
+      }
+    },
+    "node_modules/@curveball/static": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@curveball/static/-/static-0.2.1.tgz",
+      "integrity": "sha512-6h2P0/CXzOItxHdjGZtpv6yBpshqcLMrejo6vEkEkQR0WCu8BBqNcjD/a7wuy38FYLq0J/QXMidvaFL4jXHh7Q==",
+      "dependencies": {
+        "mime-types": "^2.1.29"
+      },
+      "peerDependencies": {
+        "@curveball/core": ">=0.16 <1"
       }
     },
     "node_modules/@curveball/validator": {
@@ -958,9 +997,9 @@
       }
     },
     "node_modules/@peculiar/asn1-x509": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509/-/asn1-x509-2.1.0.tgz",
-      "integrity": "sha512-eg+ZT3glLFeDg6HoFRv8S5ui/i3DVpyBglgYlbNwawEYifF0T++SHRrjLGi4ZXNI0gXRsqWyx1TR4clKVPDx3g==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509/-/asn1-x509-2.1.4.tgz",
+      "integrity": "sha512-wmNFRjHL6EMkOBSExi1EamPu3ExqdIHZ7XrpJ+v9CG/Ccr60FtvPAjEqORMcCadTtO4MDc32x1+oLk4WcmxM0g==",
       "dependencies": {
         "@peculiar/asn1-schema": "^2.1.0",
         "asn1js": "^2.3.1",
@@ -1011,9 +1050,9 @@
       }
     },
     "node_modules/@sinonjs/fake-timers": {
-      "version": "9.1.1",
-      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-9.1.1.tgz",
-      "integrity": "sha512-Wp5vwlZ0lOqpSYGKqr53INws9HLkt6JDc/pDZcPf7bchQnrXJMXPns8CXx0hFikMSGSWfvtvvpb2gtMVfkWagA==",
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-9.1.2.tgz",
+      "integrity": "sha512-BPS4ynJW/o92PUR4wgriz2Ud5gpST5vz6GQfMixEDK0Z8ZCUv2M7SkBLykH56T++Xs+8ln9zTGbOvNGIe02/jw==",
       "dev": true,
       "dependencies": {
         "@sinonjs/commons": "^1.7.0"
@@ -1090,9 +1129,9 @@
       }
     },
     "node_modules/@types/chai": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.0.tgz",
-      "integrity": "sha512-/ceqdqeRraGolFTcfoXNiqjyQhZzbINDngeoAq9GoHa8PPK1yNzTaxWjA6BFWp5Ua9JpXEMSS4s5i9tS0hOJtw==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.1.tgz",
+      "integrity": "sha512-/zPMqDkzSZ8t3VtxOa4KPq7uzzW978M9Tvh+j7GHKuo6k6GTLxPJ4J5gE5cjfJ26pnXst0N5Hax8Sr0T2Mi9zQ==",
       "dev": true
     },
     "node_modules/@types/chai-as-promised": {
@@ -1140,9 +1179,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "16.11.26",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.26.tgz",
-      "integrity": "sha512-GZ7bu5A6+4DtG7q9GsoHXy3ALcgeIHP4NnL0Vv2wu0uUB/yQex26v0tf6/na1mm0+bS9Uw+0DFex7aaKr2qawQ=="
+      "version": "16.11.27",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.27.tgz",
+      "integrity": "sha512-C1pD3kgLoZ56Uuy5lhfOxie4aZlA3UMGLX9rXteq4WitEZH6Rl80mwactt9QG0w0gLFlN/kLBTFnGXtDVWvWQw=="
     },
     "node_modules/@types/nodemailer": {
       "version": "6.4.4",
@@ -1633,6 +1672,14 @@
         "node": "*"
       }
     },
+    "node_modules/async": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+      "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+      "dependencies": {
+        "lodash": "^4.17.14"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -1747,6 +1794,14 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/buffer-writer": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/buffer-writer/-/buffer-writer-2.0.0.tgz",
@@ -1796,9 +1851,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001328",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001328.tgz",
-      "integrity": "sha512-Ue55jHkR/s4r00FLNiX+hGMMuwml/QGqqzVeMQ5thUewznU2EdULFvI3JR7JJid6OrjJNfFvHY2G2dIjmRaDDQ==",
+      "version": "1.0.30001332",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001332.tgz",
+      "integrity": "sha512-10T30NYOEQtN6C11YGg411yebhvpnC6Z102+B95eAsN0oB6KUs01ivE8u+G6FMIRtIrVlYXhL+LUwQ3/hXwDWw==",
       "dev": true,
       "funding": [
         {
@@ -1974,9 +2029,9 @@
       "integrity": "sha512-hUewv7oMjCp+wkBv5Rm0v87eJhq4woh5rSR+42YSQJKecCqgIqNkZ6lAlQms/BwHPJA5NKMRlpxPRv0n8HQW6g=="
     },
     "node_modules/commander": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-9.1.0.tgz",
-      "integrity": "sha512-i0/MaqBtdbnJ4XQs4Pmyb+oFQl+q0lsAmokVUH92SlSw4fkeAcG3bVon+Qt7hmtF+u3Het6o4VgrcY3qAoEB6w==",
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.2.0.tgz",
+      "integrity": "sha512-e2i4wANQiSXgnrBlIatyHtP1odfUp0BbV5Y5nEGbxtIrStkEOAAzCUirvLBNXHLr7kwLvJl6V+4V3XV9x7Wd9w==",
       "engines": {
         "node": "^12.20.0 || >=14"
       }
@@ -2186,9 +2241,9 @@
       "dev": true
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.107",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.107.tgz",
-      "integrity": "sha512-Huen6taaVrUrSy8o7mGStByba8PfOWWluHNxSHGBrCgEdFVLtvdQDBr9LBCF9Uci8SYxh28QNNMO0oC17wbGAg==",
+      "version": "1.4.111",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.111.tgz",
+      "integrity": "sha512-/s3+fwhKf1YK4k7btOImOzCQLpUjS6MaPf0ODTNuT4eTM1Bg4itBpLkydhOzJmpmH6Z9eXFyuuK5czsmzRzwtw==",
       "dev": true
     },
     "node_modules/elliptic": {
@@ -2558,6 +2613,14 @@
         "reusify": "^1.0.4"
       }
     },
+    "node_modules/fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
+      "dependencies": {
+        "pend": "~1.2.0"
+      }
+    },
     "node_modules/fetch-mw-oauth2": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fetch-mw-oauth2/-/fetch-mw-oauth2-1.0.0.tgz",
@@ -2765,11 +2828,31 @@
       }
     },
     "node_modules/geoip-lite": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/geoip-lite/-/geoip-lite-1.0.10.tgz",
-      "integrity": "sha1-VAFgYES1/aUNbUad8AZTA/2vTXA=",
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/geoip-lite/-/geoip-lite-1.4.4.tgz",
+      "integrity": "sha512-d/3NUZKiPfVhx88uDKjnCBxYRyXQYzxgx/aE3Dx/O0S+4D2OXVumMTrZc64B124rrygpFxyaa73SVqVGQhQ0Ww==",
+      "dependencies": {
+        "async": "2.1 - 2.6.3",
+        "chalk": "4.1 - 4.1.2",
+        "iconv-lite": "0.4.13 - 0.6.3",
+        "ip-address": "5.8.9 - 5.9.4",
+        "lazy": "1.0.11",
+        "rimraf": "2.5.2 - 2.7.1",
+        "yauzl": "2.9.2 - 2.10.0"
+      },
       "engines": {
-        "node": ">=0.5.7"
+        "node": ">=5.10.0"
+      }
+    },
+    "node_modules/geoip-lite/node_modules/rimraf": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
       }
     },
     "node_modules/get-caller-file": {
@@ -3023,9 +3106,9 @@
       }
     },
     "node_modules/https-proxy-agent": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
-      "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
       "dependencies": {
         "agent-base": "6",
         "debug": "4"
@@ -3106,6 +3189,19 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/interpret/-/interpret-2.2.0.tgz",
       "integrity": "sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw==",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/ip-address": {
+      "version": "5.9.4",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-5.9.4.tgz",
+      "integrity": "sha512-dHkI3/YNJq4b/qQaz+c8LuarD3pY24JqZWfjB8aZx1gtpc2MDILu9L9jpZe1sHpzo/yWFweQVn+U//FhazUxmw==",
+      "dependencies": {
+        "jsbn": "1.1.0",
+        "lodash": "^4.17.15",
+        "sprintf-js": "1.1.2"
+      },
       "engines": {
         "node": ">= 0.10"
       }
@@ -3373,6 +3469,11 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/jsbn": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
+      "integrity": "sha1-sBMHyym2GKHtJux56RH4A8TaAEA="
+    },
     "node_modules/jsesc": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
@@ -3417,9 +3518,9 @@
       }
     },
     "node_modules/jsrsasign": {
-      "version": "10.5.16",
-      "resolved": "https://registry.npmjs.org/jsrsasign/-/jsrsasign-10.5.16.tgz",
-      "integrity": "sha512-NnIl2WZuSB43weA+S+g9CgP10HT8anwfTXhiDhWLla8GtM2p2NL8CbuvATi+ikpVJ6RUe4zKiR3Fwvucx02Fwg==",
+      "version": "10.5.17",
+      "resolved": "https://registry.npmjs.org/jsrsasign/-/jsrsasign-10.5.17.tgz",
+      "integrity": "sha512-HcFL6xetAobRceTHT4KN69eebUI8bPsvBLPz3tn1NxM7zzw5pYAoHs7OjHV/rCnLwjmkf4C++IjNFJxe6M5Z+A==",
       "funding": {
         "url": "https://github.com/kjur/jsrsasign#donations"
       }
@@ -3458,9 +3559,9 @@
       }
     },
     "node_modules/knex": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/knex/-/knex-1.0.6.tgz",
-      "integrity": "sha512-J9jYxo0ttDJz6fCfWaBrQ16mkXQvh/FjNL+7x11IqCy/2nq8vpv1MWMBPMK9UwXYiTPdn/EU4bg1KP6eXjOVEA==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/knex/-/knex-1.0.7.tgz",
+      "integrity": "sha512-89jxuRATt4qJMb9ZyyaKBy0pQ4d5h7eOFRqiNFnUvsgU+9WZ2eIaZKrAPG1+F3mgu5UloPUnkVE5Yo2sKZUs6Q==",
       "dependencies": {
         "colorette": "2.0.16",
         "commander": "^9.1.0",
@@ -3513,6 +3614,14 @@
       "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/lazy": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/lazy/-/lazy-1.0.11.tgz",
+      "integrity": "sha1-2qBoIGKCVCwIgojpdcKXwa53tpA=",
+      "engines": {
+        "node": ">=0.2.0"
       }
     },
     "node_modules/leven": {
@@ -4455,6 +4564,11 @@
       "resolved": "https://registry.npmjs.org/pct-encode/-/pct-encode-1.0.2.tgz",
       "integrity": "sha1-uZt7BE1r18OeSDmnqAEirXUVyqU="
     },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA="
+    },
     "node_modules/pg": {
       "version": "8.7.3",
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.7.3.tgz",
@@ -5235,13 +5349,13 @@
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
     },
     "node_modules/sinon": {
-      "version": "13.0.1",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-13.0.1.tgz",
-      "integrity": "sha512-8yx2wIvkBjIq/MGY1D9h1LMraYW+z1X0mb648KZnKSdvLasvDu7maa0dFaNYdTDczFgbjNw2tOmWdTk9saVfwQ==",
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-13.0.2.tgz",
+      "integrity": "sha512-KvOrztAVqzSJWMDoxM4vM+GPys1df2VBoXm+YciyB/OLMamfS3VXh3oGh5WtrAGSzrgczNWFFY22oKb7Fi5eeA==",
       "dev": true,
       "dependencies": {
         "@sinonjs/commons": "^1.8.3",
-        "@sinonjs/fake-timers": "^9.0.0",
+        "@sinonjs/fake-timers": "^9.1.2",
         "@sinonjs/samsam": "^6.1.1",
         "diff": "^5.0.0",
         "nise": "^5.1.1",
@@ -5305,6 +5419,11 @@
       "engines": {
         "node": ">= 10.x"
       }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
+      "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug=="
     },
     "node_modules/sqlstring": {
       "version": "2.3.3",
@@ -5733,9 +5852,9 @@
       "dev": true
     },
     "node_modules/v8-compile-cache-lib": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.0.tgz",
-      "integrity": "sha512-mpSYqfsFvASnSn5qMiwrr4VKfumbPyONLCOPmsR3A6pTY/r0+tSaVbgPWSAIuzbk3lCTa+FForeTiO+wBQGkjA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
       "dev": true
     },
     "node_modules/webidl-conversions": {
@@ -5940,6 +6059,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
       }
     },
     "node_modules/yn": {
@@ -6305,9 +6433,9 @@
       "requires": {}
     },
     "@curveball/browser": {
-      "version": "0.17.3",
-      "resolved": "https://registry.npmjs.org/@curveball/browser/-/browser-0.17.3.tgz",
-      "integrity": "sha512-ZrPO21AxPzTV2zsBedugoT/5eWAfdGG0jFNHCdftRQ+Pcs2acxGDFVwRFOCAozO0yb3T+gSZyD6LSgMYV5G7oQ==",
+      "version": "0.17.4",
+      "resolved": "https://registry.npmjs.org/@curveball/browser/-/browser-0.17.4.tgz",
+      "integrity": "sha512-VG0B4e6C8q2vn+Z9a1N98ovxTIdk3jC6me/nLX8dryBn1SgkNjxwH2q7uqwl2mIUOV6seoqD9osLj2O0QnelCQ==",
       "requires": {
         "@curveball/static": "^0.2.0",
         "csv-parse": "^4.15.3",
@@ -6317,16 +6445,6 @@
         "node-fetch": "^2.6.7",
         "react": "^17.0.1",
         "react-dom": "^17.0.1"
-      },
-      "dependencies": {
-        "@curveball/static": {
-          "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/@curveball/static/-/static-0.2.1.tgz",
-          "integrity": "sha512-6h2P0/CXzOItxHdjGZtpv6yBpshqcLMrejo6vEkEkQR0WCu8BBqNcjD/a7wuy38FYLq0J/QXMidvaFL4jXHh7Q==",
-          "requires": {
-            "mime-types": "^2.1.29"
-          }
-        }
       }
     },
     "@curveball/controller": {
@@ -6338,9 +6456,9 @@
       }
     },
     "@curveball/core": {
-      "version": "0.18.0-alpha.0",
-      "resolved": "https://registry.npmjs.org/@curveball/core/-/core-0.18.0-alpha.0.tgz",
-      "integrity": "sha512-DANa7FAL1Va3kjpe7KXB+x9c5JwjL6OoMlkyeItgokGiV99vH9xjQzNZOcmFlveUTCp9p0biCg3d9r7WlR1V6A==",
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/@curveball/core/-/core-0.18.0.tgz",
+      "integrity": "sha512-8V0SSKGm1yWWXi9ATtxIneRKnhHg2gffyx0PEbJi2dUPE5xBEl/kbxFliiND9Uf6FjUCbDRuip/N9NNZakVf9Q==",
       "requires": {
         "@curveball/http-errors": "^0.4.0",
         "@types/ws": "^8.5.3",
@@ -6401,6 +6519,14 @@
       "requires": {
         "cookie": "^0.4.1",
         "redis": "^3.0.2"
+      }
+    },
+    "@curveball/static": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@curveball/static/-/static-0.2.1.tgz",
+      "integrity": "sha512-6h2P0/CXzOItxHdjGZtpv6yBpshqcLMrejo6vEkEkQR0WCu8BBqNcjD/a7wuy38FYLq0J/QXMidvaFL4jXHh7Q==",
+      "requires": {
+        "mime-types": "^2.1.29"
       }
     },
     "@curveball/validator": {
@@ -6687,9 +6813,9 @@
       }
     },
     "@peculiar/asn1-x509": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509/-/asn1-x509-2.1.0.tgz",
-      "integrity": "sha512-eg+ZT3glLFeDg6HoFRv8S5ui/i3DVpyBglgYlbNwawEYifF0T++SHRrjLGi4ZXNI0gXRsqWyx1TR4clKVPDx3g==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509/-/asn1-x509-2.1.4.tgz",
+      "integrity": "sha512-wmNFRjHL6EMkOBSExi1EamPu3ExqdIHZ7XrpJ+v9CG/Ccr60FtvPAjEqORMcCadTtO4MDc32x1+oLk4WcmxM0g==",
       "requires": {
         "@peculiar/asn1-schema": "^2.1.0",
         "asn1js": "^2.3.1",
@@ -6737,9 +6863,9 @@
       }
     },
     "@sinonjs/fake-timers": {
-      "version": "9.1.1",
-      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-9.1.1.tgz",
-      "integrity": "sha512-Wp5vwlZ0lOqpSYGKqr53INws9HLkt6JDc/pDZcPf7bchQnrXJMXPns8CXx0hFikMSGSWfvtvvpb2gtMVfkWagA==",
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-9.1.2.tgz",
+      "integrity": "sha512-BPS4ynJW/o92PUR4wgriz2Ud5gpST5vz6GQfMixEDK0Z8ZCUv2M7SkBLykH56T++Xs+8ln9zTGbOvNGIe02/jw==",
       "dev": true,
       "requires": {
         "@sinonjs/commons": "^1.7.0"
@@ -6810,9 +6936,9 @@
       }
     },
     "@types/chai": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.0.tgz",
-      "integrity": "sha512-/ceqdqeRraGolFTcfoXNiqjyQhZzbINDngeoAq9GoHa8PPK1yNzTaxWjA6BFWp5Ua9JpXEMSS4s5i9tS0hOJtw==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.1.tgz",
+      "integrity": "sha512-/zPMqDkzSZ8t3VtxOa4KPq7uzzW978M9Tvh+j7GHKuo6k6GTLxPJ4J5gE5cjfJ26pnXst0N5Hax8Sr0T2Mi9zQ==",
       "dev": true
     },
     "@types/chai-as-promised": {
@@ -6860,9 +6986,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "16.11.26",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.26.tgz",
-      "integrity": "sha512-GZ7bu5A6+4DtG7q9GsoHXy3ALcgeIHP4NnL0Vv2wu0uUB/yQex26v0tf6/na1mm0+bS9Uw+0DFex7aaKr2qawQ=="
+      "version": "16.11.27",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.27.tgz",
+      "integrity": "sha512-C1pD3kgLoZ56Uuy5lhfOxie4aZlA3UMGLX9rXteq4WitEZH6Rl80mwactt9QG0w0gLFlN/kLBTFnGXtDVWvWQw=="
     },
     "@types/nodemailer": {
       "version": "6.4.4",
@@ -7201,6 +7327,14 @@
       "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
       "dev": true
     },
+    "async": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+      "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+      "requires": {
+        "lodash": "^4.17.14"
+      }
+    },
     "balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -7285,6 +7419,11 @@
         "picocolors": "^1.0.0"
       }
     },
+    "buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI="
+    },
     "buffer-writer": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/buffer-writer/-/buffer-writer-2.0.0.tgz",
@@ -7319,9 +7458,9 @@
       "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
     },
     "caniuse-lite": {
-      "version": "1.0.30001328",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001328.tgz",
-      "integrity": "sha512-Ue55jHkR/s4r00FLNiX+hGMMuwml/QGqqzVeMQ5thUewznU2EdULFvI3JR7JJid6OrjJNfFvHY2G2dIjmRaDDQ==",
+      "version": "1.0.30001332",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001332.tgz",
+      "integrity": "sha512-10T30NYOEQtN6C11YGg411yebhvpnC6Z102+B95eAsN0oB6KUs01ivE8u+G6FMIRtIrVlYXhL+LUwQ3/hXwDWw==",
       "dev": true
     },
     "cbor": {
@@ -7445,9 +7584,9 @@
       "integrity": "sha512-hUewv7oMjCp+wkBv5Rm0v87eJhq4woh5rSR+42YSQJKecCqgIqNkZ6lAlQms/BwHPJA5NKMRlpxPRv0n8HQW6g=="
     },
     "commander": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-9.1.0.tgz",
-      "integrity": "sha512-i0/MaqBtdbnJ4XQs4Pmyb+oFQl+q0lsAmokVUH92SlSw4fkeAcG3bVon+Qt7hmtF+u3Het6o4VgrcY3qAoEB6w=="
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.2.0.tgz",
+      "integrity": "sha512-e2i4wANQiSXgnrBlIatyHtP1odfUp0BbV5Y5nEGbxtIrStkEOAAzCUirvLBNXHLr7kwLvJl6V+4V3XV9x7Wd9w=="
     },
     "commondir": {
       "version": "1.0.1",
@@ -7612,9 +7751,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.4.107",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.107.tgz",
-      "integrity": "sha512-Huen6taaVrUrSy8o7mGStByba8PfOWWluHNxSHGBrCgEdFVLtvdQDBr9LBCF9Uci8SYxh28QNNMO0oC17wbGAg==",
+      "version": "1.4.111",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.111.tgz",
+      "integrity": "sha512-/s3+fwhKf1YK4k7btOImOzCQLpUjS6MaPf0ODTNuT4eTM1Bg4itBpLkydhOzJmpmH6Z9eXFyuuK5czsmzRzwtw==",
       "dev": true
     },
     "elliptic": {
@@ -7908,6 +8047,14 @@
         "reusify": "^1.0.4"
       }
     },
+    "fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
+      "requires": {
+        "pend": "~1.2.0"
+      }
+    },
     "fetch-mw-oauth2": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fetch-mw-oauth2/-/fetch-mw-oauth2-1.0.0.tgz",
@@ -8058,9 +8205,28 @@
       "dev": true
     },
     "geoip-lite": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/geoip-lite/-/geoip-lite-1.0.10.tgz",
-      "integrity": "sha1-VAFgYES1/aUNbUad8AZTA/2vTXA="
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/geoip-lite/-/geoip-lite-1.4.4.tgz",
+      "integrity": "sha512-d/3NUZKiPfVhx88uDKjnCBxYRyXQYzxgx/aE3Dx/O0S+4D2OXVumMTrZc64B124rrygpFxyaa73SVqVGQhQ0Ww==",
+      "requires": {
+        "async": "2.1 - 2.6.3",
+        "chalk": "4.1 - 4.1.2",
+        "iconv-lite": "0.4.13 - 0.6.3",
+        "ip-address": "5.8.9 - 5.9.4",
+        "lazy": "1.0.11",
+        "rimraf": "2.5.2 - 2.7.1",
+        "yauzl": "2.9.2 - 2.10.0"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
+      }
     },
     "get-caller-file": {
       "version": "2.0.5",
@@ -8247,9 +8413,9 @@
       "integrity": "sha512-Cnv3Q+FF+35avekdnH/ML8dls++tdnSgrvUIWw0YEszrWeLSuw5Iq1vyCVTb5v0rEUgFTy0x4shxXyrO0MDUzw=="
     },
     "https-proxy-agent": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
-      "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
       "requires": {
         "agent-base": "6",
         "debug": "4"
@@ -8309,6 +8475,16 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/interpret/-/interpret-2.2.0.tgz",
       "integrity": "sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw=="
+    },
+    "ip-address": {
+      "version": "5.9.4",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-5.9.4.tgz",
+      "integrity": "sha512-dHkI3/YNJq4b/qQaz+c8LuarD3pY24JqZWfjB8aZx1gtpc2MDILu9L9jpZe1sHpzo/yWFweQVn+U//FhazUxmw==",
+      "requires": {
+        "jsbn": "1.1.0",
+        "lodash": "^4.17.15",
+        "sprintf-js": "1.1.2"
+      }
     },
     "ipaddr.js": {
       "version": "2.0.1",
@@ -8506,6 +8682,11 @@
         "argparse": "^2.0.1"
       }
     },
+    "jsbn": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
+      "integrity": "sha1-sBMHyym2GKHtJux56RH4A8TaAEA="
+    },
     "jsesc": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
@@ -8535,9 +8716,9 @@
       "integrity": "sha512-PNYZIdMjVIvVgDSYKTT63Y+KZ6IZvGRNNWcxwD+GNnUz1MKPfv30J8ueCjdwcN0nDx2SlshgyB7Oy0epAzVRRg=="
     },
     "jsrsasign": {
-      "version": "10.5.16",
-      "resolved": "https://registry.npmjs.org/jsrsasign/-/jsrsasign-10.5.16.tgz",
-      "integrity": "sha512-NnIl2WZuSB43weA+S+g9CgP10HT8anwfTXhiDhWLla8GtM2p2NL8CbuvATi+ikpVJ6RUe4zKiR3Fwvucx02Fwg=="
+      "version": "10.5.17",
+      "resolved": "https://registry.npmjs.org/jsrsasign/-/jsrsasign-10.5.17.tgz",
+      "integrity": "sha512-HcFL6xetAobRceTHT4KN69eebUI8bPsvBLPz3tn1NxM7zzw5pYAoHs7OjHV/rCnLwjmkf4C++IjNFJxe6M5Z+A=="
     },
     "just-extend": {
       "version": "4.2.1",
@@ -8570,9 +8751,9 @@
       }
     },
     "knex": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/knex/-/knex-1.0.6.tgz",
-      "integrity": "sha512-J9jYxo0ttDJz6fCfWaBrQ16mkXQvh/FjNL+7x11IqCy/2nq8vpv1MWMBPMK9UwXYiTPdn/EU4bg1KP6eXjOVEA==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/knex/-/knex-1.0.7.tgz",
+      "integrity": "sha512-89jxuRATt4qJMb9ZyyaKBy0pQ4d5h7eOFRqiNFnUvsgU+9WZ2eIaZKrAPG1+F3mgu5UloPUnkVE5Yo2sKZUs6Q==",
       "requires": {
         "colorette": "2.0.16",
         "commander": "^9.1.0",
@@ -8596,6 +8777,11 @@
           "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw=="
         }
       }
+    },
+    "lazy": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/lazy/-/lazy-1.0.11.tgz",
+      "integrity": "sha1-2qBoIGKCVCwIgojpdcKXwa53tpA="
     },
     "leven": {
       "version": "3.1.0",
@@ -9336,6 +9522,11 @@
       "resolved": "https://registry.npmjs.org/pct-encode/-/pct-encode-1.0.2.tgz",
       "integrity": "sha1-uZt7BE1r18OeSDmnqAEirXUVyqU="
     },
+    "pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA="
+    },
     "pg": {
       "version": "8.7.3",
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.7.3.tgz",
@@ -9893,13 +10084,13 @@
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
     },
     "sinon": {
-      "version": "13.0.1",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-13.0.1.tgz",
-      "integrity": "sha512-8yx2wIvkBjIq/MGY1D9h1LMraYW+z1X0mb648KZnKSdvLasvDu7maa0dFaNYdTDczFgbjNw2tOmWdTk9saVfwQ==",
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-13.0.2.tgz",
+      "integrity": "sha512-KvOrztAVqzSJWMDoxM4vM+GPys1df2VBoXm+YciyB/OLMamfS3VXh3oGh5WtrAGSzrgczNWFFY22oKb7Fi5eeA==",
       "dev": true,
       "requires": {
         "@sinonjs/commons": "^1.8.3",
-        "@sinonjs/fake-timers": "^9.0.0",
+        "@sinonjs/fake-timers": "^9.1.2",
         "@sinonjs/samsam": "^6.1.1",
         "diff": "^5.0.0",
         "nise": "^5.1.1",
@@ -9944,6 +10135,11 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/split2/-/split2-4.1.0.tgz",
       "integrity": "sha512-VBiJxFkxiXRlUIeyMQi8s4hgvKCSjtknJv/LVYbrgALPwf5zSKmEwV9Lst25AkvMDnvxODugjdl6KZgwKM1WYQ=="
+    },
+    "sprintf-js": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
+      "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug=="
     },
     "sqlstring": {
       "version": "2.3.3",
@@ -10247,9 +10443,9 @@
       "dev": true
     },
     "v8-compile-cache-lib": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.0.tgz",
-      "integrity": "sha512-mpSYqfsFvASnSn5qMiwrr4VKfumbPyONLCOPmsR3A6pTY/r0+tSaVbgPWSAIuzbk3lCTa+FForeTiO+wBQGkjA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
       "dev": true
     },
     "webidl-conversions": {
@@ -10400,6 +10596,15 @@
           "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
           "dev": true
         }
+      }
+    },
+    "yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
+      "requires": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
       }
     },
     "yn": {

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
   "dependencies": {
     "@curveball/accesslog": "^0.2.1",
     "@curveball/bodyparser": "^0.4.14",
-    "@curveball/browser": "^0.17.3",
+    "@curveball/browser": "^0.17.4",
     "@curveball/controller": "^0.3.0",
     "@curveball/core": "^0.18.0-alpha.0",
     "@curveball/cors": "^0.1.0",

--- a/src/database.ts
+++ b/src/database.ts
@@ -54,8 +54,6 @@ export async function query<T = any>(query: string, params: Knex.ValueDict | Kne
 
 }
 
-
-
 export function getSettings(): Knex.Config {
 
   let connection: Knex.MySql2ConnectionConfig | Knex.PgConnectionConfig | Knex.Sqlite3ConnectionConfig;
@@ -142,7 +140,9 @@ export function getSettings(): Knex.Config {
       case undefined :
         client = 'sqlite3';
 
-        console.warn('No database settings were found, so we\'re creating a sqlite database in the current directory. This is not recommended for production');
+        if (process.env.DB_DRIVER === undefined) {
+          console.warn('No database settings were found, so we\'re creating a sqlite database in the current directory. This is not recommended for production');
+        }
 
         connection = {
           filename: process.env.DB_FILENAME || 'a12nserver.sqlite3'

--- a/src/database.ts
+++ b/src/database.ts
@@ -34,7 +34,7 @@ type RawResult<T> = RawMySQLResult<T> | RawPostgreSQLResult<T> | RawSqlite3Resul
  * A shortcut for easily executing select queries.
  *
  * Use of this should be phased out, but it helped with the migration from
- * befre knex.
+ * before knex.
  */
 export async function query<T = any>(query: string, params: Knex.ValueDict | Knex.RawBinding[] = []): Promise<T[]> {
 

--- a/src/database.ts
+++ b/src/database.ts
@@ -5,7 +5,9 @@ import * as path from 'node:path';
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 require('dotenv').config();
 
+let settings: Knex.Config | null = null;
 const db: Knex = knex(getSettings());
+
 
 export async function init() {
 
@@ -17,14 +19,53 @@ export async function init() {
 
 export default db;
 
+type RawMySQLResult<T> = [ T[], [] ];
+type RawPostgreSQLResult<T> = {
+  rows: T[];
+}
+
+type RawSqlite3Result<T> = T[];
+
+type RawResult<T> = RawMySQLResult<T> | RawPostgreSQLResult<T> | RawSqlite3Result<T>;
+
+
+
+/**
+ * A shortcut for easily executing select queries.
+ *
+ * Use of this should be phased out, but it helped with the migration from
+ * befre knex.
+ */
+export async function query<T = any>(query: string, params: Knex.ValueDict | Knex.RawBinding[] = []): Promise<T[]> {
+
+  // Knex returns weird typings for the raw function,
+  const result = (await db.raw(query, params)) as RawResult<T>;
+
+  switch (settings?.client) {
+    case 'pg':
+      return (result as RawPostgreSQLResult<T>).rows;
+    case 'sqlite3':
+      return (result as RawSqlite3Result<T>);
+    case 'mysql2':
+      return (result as RawMySQLResult<T>)[0];
+    default:
+      throw new Error(`Unknown driver: ${settings?.client}`);
+  }
+
+}
+
+
+
 export function getSettings(): Knex.Config {
 
   let connection: Knex.MySql2ConnectionConfig | Knex.PgConnectionConfig | Knex.Sqlite3ConnectionConfig;
   let client;
   let searchPath;
 
-  // Declare explicitly the client to use, or try to infer it.
-  if (Object.keys(process.env).includes('PG_DATABASE')) {
+  if (process.env.PG_DATABASE) {
+
+    // Old way to connect to Postgres
+
     client = 'pg';
     connection = {
       host: process.env.PG_HOST || '127.0.0.1',
@@ -37,7 +78,10 @@ export function getSettings(): Knex.Config {
       connection.user as string,
       connection.database as string,
     ];
-  } else if (Object.keys(process.env).includes('MYSQL_DATABASE')) {
+
+  } else if (process.env.MYSQL_DATABASE) {
+
+    // Old way to connect to MySQL
     client = 'mysql2';
     connection = {
       host: process.env.MYSQL_HOST || '127.0.0.1',
@@ -53,16 +97,65 @@ export function getSettings(): Knex.Config {
       delete connection.host;
       delete connection.port;
     }
+
   } else {
 
-    console.warn('Warning! No database settings provided, so we\'re using an in-memory database that will be erased upon restart!');
-    client = 'sqlite3';
-    connection = {
-      filename: ':memory:',
-    };
+    switch(process.env.DB_DRIVER) {
+
+      case 'pg':
+        client = 'pg';
+        connection = {
+          host: process.env.DB_HOST || '127.0.0.1',
+          port: parseInt(process.env.DB_PORT as string, 10) || 5432,
+          user: process.env.DB_USER,
+          password: process.env.DB_PASSWORD,
+          database: process.env.DB_DATABASE,
+        };
+        searchPath = [
+          connection.user as string,
+          connection.database as string,
+        ];
+        break;
+      case 'mysql' :
+      case 'mysql2' :
+        client = 'mysql2';
+        connection = {
+          host: process.env.DB_HOST || '127.0.0.1',
+          port: parseInt(process.env.DB_PORT as string, 10) || 3306,
+          user: process.env.DB_USER,
+          password: process.env.DB_PASSWORD,
+          database: process.env.DB_DATABASE,
+        };
+
+        if (process.env.MYSQL_INSTANCE_CONNECTION_NAME) {
+          (connection as Knex.MySql2ConnectionConfig).socketPath = '/cloudsql/' + process.env.MYSQL_INSTANCE_CONNECTION_NAME;
+        } else {
+          delete connection.host;
+          delete connection.port;
+        }
+        break;
+
+      case 'sqlite' :
+      case 'sqlite3' :
+      case undefined :
+        client = 'sqlite3';
+
+        console.warn('No database settings were found, so we\'re creating a sqlite database in the current directory. This is not recommended for production');
+
+        connection = {
+          filename: process.env.DB_FILENAME || 'a12nserver.sqlite3'
+        };
+        break;
+
+      default:
+        throw new Error(`Unknown value for DB_DRIVER: ${process.env.DB_DRIVER}`);
+
+
+    }
+
   }
 
-  return {
+  settings = {
     client,
     connection,
     searchPath,
@@ -73,29 +166,6 @@ export function getSettings(): Knex.Config {
     pool: { min: 0, max: 10 },
     debug: process.env.DEBUG ? true : false,
   };
-}
 
-type RawMySQLResult<T> = [ T[], [] ];
-interface RawPostgreSQLResult<T> {
-  rows: T[];
-}
-type RawResult<T> = RawMySQLResult<T> | RawPostgreSQLResult<T>;
-
-/**
- * A shortcut for easily executing select queries.
- *
- * Use of this should be phased out, but it helped with the migration from
- * befre knex.
- */
-export async function query<T = any>(query: string, params: Knex.ValueDict | Knex.RawBinding[] = []): Promise<T[]> {
-
-  // Knex returns weird typings for the raw function,
-  const result = (await db.raw(query, params)) as RawResult<T>;
-
-  if (db.client.deviceName === 'pg') {
-    return (result as RawPostgreSQLResult<T>).rows;
-  }
-
-  return (result as RawMySQLResult<T>)[0];
-
+  return settings;
 }

--- a/src/database.ts
+++ b/src/database.ts
@@ -64,7 +64,7 @@ export function getSettings(): Knex.Config {
 
   if (process.env.PG_DATABASE) {
 
-    // Old way to connect to Postgres
+    console.warn('The PG_* environment variables are deprecated. Use DB_DRIVER=pg, DB_HOST, DB_USER, DB_PASSWORD, DB_DATABASE instead');
 
     client = 'pg';
     connection = {
@@ -79,9 +79,11 @@ export function getSettings(): Knex.Config {
       connection.database as string,
     ];
 
+
   } else if (process.env.MYSQL_DATABASE) {
 
-    // Old way to connect to MySQL
+    console.warn('The MYSQL_* environment variables are deprecated. Use DB_DRIVER=mysql, DB_HOST, DB_USER, DB_PASSWORD, DB_DATABASE instead');
+
     client = 'mysql2';
     connection = {
       host: process.env.MYSQL_HOST || '127.0.0.1',

--- a/src/home/formats/hal.ts
+++ b/src/home/formats/hal.ts
@@ -45,6 +45,8 @@ export default (version: string, authenticatedUser: Principal, isAdmin: boolean,
         title: 'List of JSON schemas for this API'
       },
 
+
+
       'oauth_server_metadata_uri' : {
         href: '/.well-known/oauth-authorization-server',
         title: 'OAuth 2.0 Authorization Server Metadata'
@@ -71,6 +73,10 @@ export default (version: string, authenticatedUser: Principal, isAdmin: boolean,
     result._links['exchange-one-time-token'] = {
       href: '/exchange-one-time-token',
       title: 'Exchange a one-time token for a Access and Refresh token',
+    };
+    result._links['settings'] = {
+      href: '/settings',
+      title: 'Server settings',
     };
   }
 

--- a/src/home/formats/markdown.ts
+++ b/src/home/formats/markdown.ts
@@ -50,8 +50,10 @@ OAuth2 endpoints
 Other API endpoints
 -------------------
 
-* ${isAdmin?'<a href="/exchange-one-time-token" rel="exchange-one-time-token">Exchange one-time-token</a>':''}
+  ${isAdmin?`* <a href="/settings" rel="settings">Server settings</a>
+* <a href="/exchange-one-time-token" rel="exchange-one-time-token">Exchange one-time-token</a>
 * <a href="/schema" rel="schema-collection">JSON Schema collection</a>
+`:''}
 
 _Version ${version}_
 

--- a/src/main-mw.ts
+++ b/src/main-mw.ts
@@ -68,8 +68,8 @@ export default function(): Middleware {
   /**
    * This middleware contains all the a12n-server functionality.
    */
-  return ctx => {
-    return invokeMiddlewares(ctx, middlewares);
+  return (ctx, next) => {
+    return invokeMiddlewares(ctx, [...middlewares, next]);
   };
 
 }

--- a/src/oauth2-client/controller/collection.ts
+++ b/src/oauth2-client/controller/collection.ts
@@ -55,7 +55,7 @@ class ClientCollectionController extends Controller {
     const redirectUris = ctx.request.body.redirectUris.trim().split(/\r\n|\n/).filter((line:string) => !!line);
 
     if (!clientId) {
-      clientId = await generateSecretToken(10);
+      clientId = `secret-token:${await generateSecretToken(10)}`;
     } else if (clientId.length < 6) {
       throw new UnprocessableEntity('clientId must be at least 6 characters or left empty');
     }

--- a/src/principal/service.ts
+++ b/src/principal/service.ts
@@ -100,8 +100,6 @@ export async function findActiveById(id: number): Promise<Principal> {
 export async function hasPrincipals(): Promise<boolean> {
 
   const result = await query('SELECT 1 FROM principals LIMIT 1');
-  console.log(result);
-
   return result.length > 0;
 
 }

--- a/src/principal/service.ts
+++ b/src/principal/service.ts
@@ -100,6 +100,7 @@ export async function findActiveById(id: number): Promise<Principal> {
 export async function hasPrincipals(): Promise<boolean> {
 
   const result = await query('SELECT 1 FROM principals LIMIT 1');
+  console.log(result);
 
   return result.length > 0;
 

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -33,6 +33,7 @@ import register from './register/controller/user';
 import registerMfa from './register/controller/mfa';
 import registerTotp from './mfa/totp/controller/register';
 import registerWebAuthn from './mfa/webauthn/controller/register';
+import settings from './settings/controller';
 import webAuthnRegistration from './mfa/webauthn/controller/registration';
 import resetPassword from './reset-password/controller/request';
 import resetPasswordRedirect from './reset-password/controller/reset-password';
@@ -88,6 +89,8 @@ const routes = [
   router('/register/mfa/totp', registerTotp),
   router('/register/mfa/webauthn', registerWebAuthn),
   router('/register/mfa/webauthn/registration', webAuthnRegistration),
+
+  router('/settings', settings),
 
   router('/user', users),
   router('/user/byhref/:href', userByHref),

--- a/src/server-settings.ts
+++ b/src/server-settings.ts
@@ -69,7 +69,7 @@ export const settingsRules: SettingsRules = {
   },
   'redis.uri': {
     description: 'Redis server URI',
-    fromDb: true,
+    fromDb: false,
     default: null,
     env: 'REDIS_URI',
   },

--- a/src/server-settings.ts
+++ b/src/server-settings.ts
@@ -1,10 +1,20 @@
 import db from './database';
 
-type Settings = {
+export type Settings = {
   'login.defaultRedirect': string;
   'registration.enabled': boolean;
   'registration.mfa.enabled': boolean;
   'cors.allowOrigin': string[] | null;
+
+  'db.driver': 'mysql2' | 'pg' | 'sqlite3' | 'mysql';
+  'db.host': string | null;
+  'db.user': string;
+  'db.password': string | null;
+  'db.database': string;
+  'db.filename': string;
+  'db.mysql_instance_connection_name': string | null;
+
+  'redis.uri': null | string;
 
   'smtp.url': null | string;
   'smtp.emailFrom': null | string;
@@ -25,7 +35,7 @@ type Settings = {
 
 }
 
-type SettingsRules = {
+export type SettingsRules = {
   [Setting in keyof Settings]: {
     description: string;
     env?: string;
@@ -35,7 +45,7 @@ type SettingsRules = {
   }
 }
 
-const settingsRules: SettingsRules = {
+export const settingsRules: SettingsRules = {
   'logo_url' : {
     description: 'The application logo to display on the a12nserver pages',
     fromDb: true,
@@ -57,10 +67,67 @@ const settingsRules: SettingsRules = {
     fromDb: true,
     default: true,
   },
+  'redis.uri': {
+    description: 'Redis server URI',
+    fromDb: true,
+    default: null,
+    env: 'REDIS_URI',
+  },
   'cors.allowOrigin': {
     description: 'List of allowed origins that may directly talk to the server. This should only ever be 1st party, trusted domains. By default CORS is not enabled',
     fromDb: true,
     default: null,
+  },
+
+  'db.driver': {
+    description: 'Database client to use. Only "pg", "sqlite3" and "mysql" are supported',
+    fromDb: false,
+    default: 'sqlite3',
+    env: 'DB_CLIENT',
+  },
+
+  'db.host': {
+    description: 'Database hostname. Required for postgres and mysql2, but must be omitted for sqlite',
+    fromDb: false,
+    default: null,
+    env: 'DB_HOST',
+  },
+
+  'db.user': {
+    description: 'Database user. Required for postgres and mysql2.',
+    fromDb: false,
+    default: 'a12nserver',
+    env: 'DB_USER',
+  },
+
+  'db.password': {
+    description: 'Database password',
+    fromDb: false,
+    default: null,
+    env: 'DB_PASSWORD',
+    isSecret: true,
+  },
+
+  'db.database': {
+    description: 'Name of the database. Required for postgres and mysql2',
+    fromDb: false,
+    default: 'a12nserver',
+    env: 'DB_DATABASE',
+  },
+
+  'db.mysql_instance_connection_name': {
+    description: 'MySQL instance connection name. This environment variable allows a Google Cloud installation to automatically discover the MySQL instance, and should normally not be provided manually',
+    fromDb: false,
+    default: null,
+    env: 'MYSQL_INSTANCE_CONNECTION_NAME',
+  },
+
+
+  'db.filename': {
+    description: 'Path to database. Only used by sqlite3 driver',
+    fromDb: false,
+    default: ':memory:',
+    env: 'DB_FILENAME',
   },
 
   'smtp.url' : {
@@ -75,8 +142,6 @@ const settingsRules: SettingsRules = {
     fromDb: true,
     default: null,
   },
-
-
 
   'oauth2.code.expiry': {
     description: 'The expiry time (in seconds) for the \'code\' from the oauth2 authorization code grant type',
@@ -102,6 +167,7 @@ const settingsRules: SettingsRules = {
     env: 'JWT_PRIVATE_KEY',
     fromDb: false,
     default: null,
+    isSecret: true,
   },
 
   'totp': {
@@ -185,7 +251,14 @@ export function requireSetting<T extends keyof Settings>(setting: T): Settings[T
 
 }
 
+export function getSettings(): Settings {
 
+  if (settingsCache === null) {
+    throw new Error('Settings have not been loaded. Call load() first');
+  }
+
+  return settingsCache;
+}
 
 /**
  * Loads or reloads settings from the database.

--- a/src/settings/controller.ts
+++ b/src/settings/controller.ts
@@ -1,0 +1,49 @@
+import { Controller, method, accept } from '@curveball/controller';
+import { Context } from '@curveball/core';
+import { Forbidden } from '@curveball/http-errors';
+import * as privilegeService from '../privilege/service';
+import { getSettings, settingsRules } from '../server-settings';
+import * as hal from './formats/hal';
+import * as csv from './formats/csv';
+
+class SettingsController extends Controller {
+
+  @method('GET')
+  @accept('application/hal+json')
+  async getJson(ctx: Context) {
+
+    if (!await privilegeService.hasPrivilege(ctx, 'admin')) {
+      throw new Forbidden('Only users with the "admin" privilege can inspect OAuth2 clients that are not your own');
+    }
+
+    ctx.response.links.add({
+      href: ctx.path,
+      rel: 'alternate',
+      type: 'text/csv'
+    });
+
+    ctx.response.body = hal.settings(settingsRules, getSettings());
+
+  }
+
+  @method('GET')
+  @accept('csv')
+  async getCsv(ctx: Context) {
+
+    if (!await privilegeService.hasPrivilege(ctx, 'admin')) {
+      throw new Forbidden('Only users with the "admin" privilege can inspect OAuth2 clients that are not your own');
+    }
+    ctx.response.links.add({
+      href: ctx.path,
+      rel: 'alternate',
+      type: 'application/hal+json'
+    });
+
+    ctx.response.type = 'text/csv';
+    ctx.response.body = csv.settings(settingsRules, getSettings());
+
+  }
+
+}
+
+export default new SettingsController();

--- a/src/settings/formats/csv.ts
+++ b/src/settings/formats/csv.ts
@@ -1,0 +1,34 @@
+import { SettingsRules, Settings } from '../../server-settings';
+import { stringify } from 'csv-stringify/sync';
+
+export function settings(settingsRules: SettingsRules, settings: Settings): string {
+
+  const settingsTable = Object.keys(settingsRules).map(key => {
+
+    const rule = settingsRules[key as keyof Settings];
+    const value = rule.isSecret ? null : settings[key as keyof Settings];
+
+    return {
+      name: key,
+      ...rule,
+      value,
+    };
+
+  });
+
+  return stringify(settingsTable, {
+    header: true,
+    columns: {
+      name: 'Name',
+      value: 'Value',
+      default: 'Default',
+      fromDb: 'Settable in database',
+      env: 'Environment variable name',
+      isSecret: 'Secret',
+    },
+    cast: {
+      boolean: v => v ? 'true' : 'false',
+    }
+  });
+
+}

--- a/src/settings/formats/hal.ts
+++ b/src/settings/formats/hal.ts
@@ -1,0 +1,22 @@
+import { SettingsRules, Settings } from '../../server-settings';
+import { HalResource } from 'hal-types';
+
+export function settings(settingsRules: SettingsRules, settings: Settings): HalResource {
+
+  return {
+    _links: {
+      self: { href: '/settings', title: 'Server settings'},
+    },
+    settings: Object.fromEntries(
+      Object.entries(settingsRules).map( ([key, value]:[string, any]) => {
+
+        if (!value.isSecret) {
+          value.value = settings[key as keyof Settings];
+        }
+        return [key, value];
+
+      })
+    ),
+  };
+
+}


### PR DESCRIPTION
This PR

* Introduces an admin-only 'settings' page which lets admins see what settings have been applied, and in the future maybe even change settings.
* Changes some of the environment variables for database setup. Now there's a generic `DB_HOST` instead of a `PG_HOST` and `MYSQL_HOST`, but the other 3 are still supported for backwards compatibility.
* Automatically generates a local sqlite3 database in a file instead of memory, so developers can get started very fast. Sqlite3 still needs work before it fully works though.
* Fixes a bug with 404 pages resulting a totally blank response.