### PR TITLE
Configurable keepAlive timeout on HTTP server

### DIFF
--- a/.env.defaults
+++ b/.env.defaults
@@ -1,6 +1,11 @@
 # TCP port to run on
 PORT=8531
 
+# HTTP Server's keep-alive timout
+# If using a Load Balancer ensure this is greater than
+# the Load Balancer's idle timeout to avoid potential race conditions.
+KEEP_ALIVE_TIMEOUT_MS=60
+
 # Public URL. This must be the URL that users will use to access a12nserver.
 # If this is not provided or incorrect, this will result in the server not
 # functioning correctly.

--- a/.env.defaults
+++ b/.env.defaults
@@ -4,7 +4,7 @@ PORT=8531
 # HTTP Server's keep-alive timout
 # If using a Load Balancer ensure this is greater than
 # the Load Balancer's idle timeout to avoid potential race conditions.
-KEEP_ALIVE_TIMEOUT_MS=60
+KEEP_ALIVE_TIMEOUT_MS=
 
 # Public URL. This must be the URL that users will use to access a12nserver.
 # If this is not provided or incorrect, this will result in the server not

--- a/src/app.ts
+++ b/src/app.ts
@@ -33,7 +33,11 @@ if (!process.env.PUBLIC_URI) {
   }));
   app.use(mainMw());
 
-  app.listen(port);
+  const httpServer = app.listen(port);
+  if (process.env.KEEP_ALIVE_TIMEOUT_MS) {
+    httpServer.keepAliveTimeout = parseInt(process.env.KEEP_ALIVE_TIMEOUT_MS, 10);
+  }
+
   console.log('Running on \x1b[31m%s\x1b[0m', app.origin + '/');
 
 })().catch( (err) => {


### PR DESCRIPTION
Making this configurable so we can solve the issue with the idle timeout race condition from any load balancers that might be in front of the server.