### PR TITLE
Adding a 'a12nserver' executable

### DIFF
--- a/bin/a12n-server
+++ b/bin/a12n-server
@@ -14,7 +14,7 @@ if (!isConfigured()) {
   console.info('a12nserver not configured! Writing default configuration to ".env"');
   fs.copyFileSync(path.join(__dirname + '/../.env.defaults'), path.join(process.cwd(), './.env'));
 
-  // Reloading .denv
+  // Reloading .env
   dotenv.config();
 
 }

--- a/bin/a12n-server
+++ b/bin/a12n-server
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+
+/* Some eslint overrides since we're in Javascript land here */
+
+/* eslint "@typescript-eslint/no-var-requires": 0 */
+
+const fs = require('node:fs');
+const path = require('node:path');
+const dotenv = require('dotenv');
+
+dotenv.config();
+
+if (!isConfigured()) {
+  console.info('a12nserver not configured! Writing default configuration to ".env"');
+  fs.copyFileSync(path.join(__dirname + '/../.env.defaults'), path.join(process.cwd(), './.env'));
+
+  // Reloading .denv
+  dotenv.config();
+
+}
+
+require('../dist/app.js');
+
+function isConfigured() {
+
+  // A very simple heuristic to see if configuration exists.
+  return process.env.MYSQL_HOST !== undefined || process.env.DB_DRIVER !== undefined || fs.existsSync('.env');
+
+}
+

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "start": "node ./dist/app.js",
     "start:watch": "tsc-watch --onSuccess 'node dist/app.js'"
   },
+  "bin": "./bin/a12n-server",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/curveball/a12n-server.git"


### PR DESCRIPTION
After this is released, this will allow a person to start a fresh copy of a12nserver (with sqlite database) just by running:

    npx @curveball/a12n-server

Running that command will create `.env` and `a12nserver.sqlite3` in the current directory. No installation required.