### PR TITLE
Login/Registration redirect improvements

### DIFF
--- a/src/login/controller/login.ts
+++ b/src/login/controller/login.ts
@@ -19,7 +19,9 @@ class LoginController extends Controller {
 
     const firstRun = !(await principalService.hasPrincipals());
     if (firstRun) {
-      ctx.redirect(302, '/register');
+      // The 'continue' query parameter contains the URL we want to redirect to after registration
+      const params = ctx.query.continue ? '?' + new URLSearchParams({continue: ctx.query.continue}) : '';
+      ctx.redirect(302, '/register' + params);
       return;
     }
 

--- a/src/mfa/totp/controller/register.ts
+++ b/src/mfa/totp/controller/register.ts
@@ -53,7 +53,12 @@ class TOTPRegisterController extends Controller {
       user,
       secret
     });
-    return ctx.redirect(303, '/login?msg=Registration+successful.+Please log in');
+    if (ctx.session.registerContinueUrl) {
+      delete ctx.session.registerContinueUrl;
+      return ctx.redirect(303, ctx.session.registerContinueUrl);
+    } else {
+      return ctx.redirect(303, '/login?msg=Registration+successful.+Please log in');
+    }
   }
 }
 

--- a/src/middleware/login.ts
+++ b/src/middleware/login.ts
@@ -120,7 +120,7 @@ export default function(): Middleware {
 
     // Not logged in.
     ctx.status = 303;
-    ctx.response.headers.set('Location', '/login');
+    ctx.response.headers.set('Location', '/login?continue=' + encodeURIComponent(ctx.request.requestTarget));
 
   };
 

--- a/src/register/controller/user.ts
+++ b/src/register/controller/user.ts
@@ -81,6 +81,7 @@ class UserRegistrationController extends Controller {
     if (addMfa && getSetting('registration.mfa.enabled')) {
       ctx.session = {
         registerUser: user,
+        registerContinueUrl: body.continue,
       };
 
       ctx.response.status = 303;

--- a/src/register/formats/html.ts
+++ b/src/register/formats/html.ts
@@ -1,6 +1,11 @@
 import { render } from '../../templates';
 
-export function registrationForm(msg: string, error: string, mfaRegistrationEnabled: boolean, firstRunMode: boolean): string {
+export function registrationForm(msg: string, error: string, mfaRegistrationEnabled: boolean, firstRunMode: boolean, continueUrl?: string): string {
+
+  const hiddenFields: Record<string,string> = {};
+  if (continueUrl) {
+    hiddenFields.continue = continueUrl;
+  }
 
   return render('register/user', {
     title: firstRunMode ? 'Create Admin Account' : 'Register',
@@ -8,6 +13,7 @@ export function registrationForm(msg: string, error: string, mfaRegistrationEnab
     error: error,
     action: '/register',
     mfaRegistrationEnabled,
+    hiddenFields,
   });
 
 }


### PR DESCRIPTION
If you hit a URL and not logged in on a12nserver, you will get a login screen. Before this change you would always get redirected to the root after login.

This change makes it so you go to the URL you originally intended to go.

In addition, this also allows a `?continue` query parameter to be specified on registration endpoints. This means we can generate links that let users to go through the registration process and afterwards go to a url of the developers choosing.