### PR TITLE
Refactoring OAuth2 service

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,9 +2,8 @@ name: Docker
 
 on:
   push:
-    # Publish `master` as Docker `latest` image.
     branches:
-      - master
+      - main
 
     # Publish `v1.2.3` tags as releases.
     tags:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,6 @@ on:
   push:
     branches: [ main ]
   pull_request:
-    branches: [ main ]
 
 jobs:
   build:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -104,3 +104,18 @@ jobs:
         PG_DATABASE: a12nserver
         PG_HOST: 127.0.0.1
       run: make migrate
+  sqlite:
+    name: Test Sqlite migrations
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - run: npm ci
+    - name: Run migrations
+      env:
+        DB_DRIVER: sqlite3
+      run: make migrate

--- a/src/db-types.ts
+++ b/src/db-types.ts
@@ -50,7 +50,7 @@ export type Oauth2CodesRecord = {
   code: string;
   user_id: number;
   code_challenge: string | null;
-  code_challenge_method: 'plain' | 'S256' | null | null;
+  code_challenge_method: 'plain' | 'S256' | null;
   created: number;
   browser_session_id: string | null;
 }
@@ -69,8 +69,18 @@ export type Oauth2TokensRecord = {
   user_id: number;
   access_token_expires: number;
   refresh_token_expires: number;
-  created: number;
+  created_at: number;
   browser_session_id: string | null;
+
+  /**
+   * 1=implicit, 2=client_credentials, 3=password, 4=authorization_code, 5=authorization_code with secret
+   */
+  grant_type: number | null;
+
+  /**
+   * OAuth2 scopes, comma separated
+   */
+  scope: string | null;
 }
 
 export type PrincipalsRecord = {

--- a/src/home/formats/markdown.ts
+++ b/src/home/formats/markdown.ts
@@ -2,24 +2,39 @@ import { App, User } from '../../principal/types';
 import { getSetting } from '../../server-settings';
 import { ServerStats } from '../../types';
 
-
 function statsBlock(kind: string, count: number): string {
 
   return `
 <div class="statsBlock">
 
   <div class="counter">
-    <span class="num">${count}</span>
+    <span class="num">${humanNum(count)}</span>
     <span class="kind">${kind}${count!=1?'s':''}</span>
   </div>
 
-  <div class="actions"><a href="/${kind}" rel="${kind}-collection">Manage</a></div>
+  ${kind!=='token' ? `<div class="actions"><a href="/${kind}" rel="${kind}-collection">Manage</a></div>`: ''}
 
 </div>
 `;
 
 }
 
+function humanNum(i: number): string {
+
+  switch(true) {
+    case i >= 10_000_000 :
+      return (i / 1_000_000).toFixed(0) + 'M';
+    case i >= 1_000_000 :
+      return (i / 1_000_000).toFixed(1) + 'M';
+    case i >= 1_0000 :
+      return (i / 1_000).toFixed(0) + 'K';
+    case i >= 1_000:
+      return (i / 1_000).toFixed(1) + 'K';
+    default :
+      return i.toString();
+  }
+
+}
 
 export default (version: string, authenticatedUser: User | App, isAdmin: boolean, serverStats: ServerStats) => {
 
@@ -28,6 +43,7 @@ export default (version: string, authenticatedUser: User | App, isAdmin: boolean
   ${statsBlock('user', serverStats.user)}
   ${statsBlock('app', serverStats.app)}
   ${statsBlock('group', serverStats.group)}
+  ${statsBlock('token', serverStats.tokensIssued)}
   ${statsBlock('privilege', serverStats.privileges)}
 </div>
 
@@ -63,5 +79,3 @@ _Version ${version}_
 `;
 
 };
-
-

--- a/src/home/service.ts
+++ b/src/home/service.ts
@@ -1,12 +1,14 @@
 import { ServerStats } from '../types';
 import { getPrincipalStats } from '../principal/service';
 import { findPrivileges } from '../privilege/service';
+import { lastTokenId } from '../oauth2/service';
 
 export async function getServerStats(): Promise<ServerStats> {
 
   return {
     ...await getPrincipalStats(),
-    privileges: (await findPrivileges()).length
+    privileges: (await findPrivileges()).length,
+    tokensIssued: (await lastTokenId()),
   };
 
 }

--- a/src/introspect/controller.ts
+++ b/src/introspect/controller.ts
@@ -68,7 +68,7 @@ class IntrospectionController extends Controller {
 
     }
     if (foundToken) {
-      const privileges = await privilegeService.getPrivilegesForPrincipal(foundToken.user);
+      const privileges = await privilegeService.getPrivilegesForPrincipal(foundToken.principal);
 
       switch (foundTokenType!) {
 

--- a/src/introspect/formats/json.ts
+++ b/src/introspect/formats/json.ts
@@ -9,12 +9,12 @@ export function accessToken(token: OAuth2Token, privileges: PrivilegeMap) {
     scope: Object.values(privileges).join(' '),
     privileges: privileges,
     client_id: token.clientId,
-    username: token.user.nickname,
+    username: token.principal.nickname,
     token_type: 'bearer',
     exp: token.accessTokenExpires,
     _links: {
       'authenticated-as': {
-        href: url.resolve(process.env.PUBLIC_URI!, '/user/' + token.user.id),
+        href: url.resolve(process.env.PUBLIC_URI!, token.principal.href),
       }
     }
   };
@@ -28,11 +28,11 @@ export function refreshToken(token: OAuth2Token, privileges: PrivilegeMap) {
     scope: Object.values(privileges).join(' '),
     privileges: privileges,
     client_id: token.clientId,
-    username: token.user.nickname,
+    username: token.principal.nickname,
     token_type: 'refresh_token',
     _links: {
       'authenticated-as': {
-        href: url.resolve(process.env.PUBLIC_URI!, '/user/' + token.user.id),
+        href: url.resolve(process.env.PUBLIC_URI!, token.principal.href),
       }
     }
   };

--- a/src/middleware/login.ts
+++ b/src/middleware/login.ts
@@ -99,7 +99,7 @@ export default function(): Middleware {
         }
       }
       // We are logged in!
-      ctx.auth = new AuthHelper(token.user);
+      ctx.auth = new AuthHelper(token.principal);
 
       return next();
 

--- a/src/migrations/20220911180000_token_metadata.ts
+++ b/src/migrations/20220911180000_token_metadata.ts
@@ -1,0 +1,23 @@
+import { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.alterTable('oauth2_tokens', table => {
+    table
+      .renameColumn('created', 'created_at');
+    table
+      .tinyint('grant_type')
+      .unsigned()
+      .nullable()
+      .comment('1=implicit, 2=client_credentials, 3=password, 4=authorization_code, 5=authorization_code with secret,6=one-time-token');
+    table
+      .string('scope', 1024)
+      .nullable()
+      .comment('OAuth2 scopes, space separated');
+  });
+}
+
+export async function down(knex: Knex): Promise<void> {
+
+  throw new Error('This migration cannot be undone');
+
+}

--- a/src/oauth2-client/controller/collection.ts
+++ b/src/oauth2-client/controller/collection.ts
@@ -1,12 +1,14 @@
+import * as bcrypt from 'bcrypt';
 import Controller from '@curveball/controller';
 import { Context } from '@curveball/core';
-import * as privilegeService from '../../privilege/service';
-import * as hal from '../formats/hal';
 import { Forbidden, UnprocessableEntity } from '@curveball/http-errors';
-import { findByApp, create } from '../service';
+
+import * as hal from '../formats/hal';
 import * as principalService from '../../principal/service';
-import { GrantType, OAuth2Client } from '../types';
-import * as bcrypt from 'bcrypt';
+import * as privilegeService from '../../privilege/service';
+import { GrantType } from '../../types';
+import { OAuth2Client } from '../types';
+import { findByApp, create } from '../service';
 import { generatePublicId, generateSecretToken } from '../../crypto';
 
 class ClientCollectionController extends Controller {

--- a/src/oauth2-client/controller/edit.ts
+++ b/src/oauth2-client/controller/edit.ts
@@ -6,7 +6,7 @@ import { Forbidden, NotFound, UnprocessableEntity } from '@curveball/http-errors
 import * as principalService from '../../principal/service';
 import { findByClientId, edit } from '../service';
 import * as oauth2Service from '../../oauth2/service';
-import { GrantType } from '../types';
+import { GrantType } from '../../types';
 
 class EditClientController extends Controller {
 

--- a/src/oauth2-client/service.ts
+++ b/src/oauth2-client/service.ts
@@ -1,14 +1,16 @@
-import { OAuth2Client, GrantType } from './types';
 import * as bcrypt from 'bcrypt';
-import * as principalService from '../principal/service';
-import db, { insertAndGetId } from '../database';
 import { Context } from '@curveball/core';
 import { NotFound, Unauthorized, Conflict } from '@curveball/http-errors';
+import { Oauth2ClientsRecord } from 'knex/types/tables';
+import { wrapError, UniqueViolationError } from 'db-errors';
+
+import { OAuth2Client } from './types';
+import * as principalService from '../principal/service';
+import db, { insertAndGetId } from '../database';
 import { InvalidRequest } from '../oauth2/errors';
 import parseBasicAuth from './parse-basic-auth';
 import { App } from '../principal/types';
-import { Oauth2ClientsRecord } from 'knex/types/tables';
-import { wrapError, UniqueViolationError } from 'db-errors';
+import { GrantType } from '../types';
 
 export async function findByClientId(clientId: string): Promise<OAuth2Client> {
 

--- a/src/oauth2-client/types.ts
+++ b/src/oauth2-client/types.ts
@@ -1,6 +1,5 @@
 import { App } from '../principal/types';
-
-export type GrantType = 'refresh_token' | 'client_credentials' | 'password' | 'implicit' | 'authorization_code';
+import { GrantType } from '../types';
 
 /**
  * The OAuth2 client refers to a single (programmatic) client, accessing

--- a/src/oauth2/controller/authorize.ts
+++ b/src/oauth2/controller/authorize.ts
@@ -101,10 +101,12 @@ class AuthorizeController extends Controller {
 
   async tokenRedirect(ctx: Context, oauth2Client: OAuth2Client, redirectUri: string, state: string|undefined) {
 
-    const token = await oauth2Service.generateTokenForUser(
-      oauth2Client,
-      ctx.session.user
-    );
+    const token = await oauth2Service.generateTokenImplicit({
+      client: oauth2Client,
+      scope: ctx.params.scope?.split(' ') ?? null,
+      principal: ctx.session.user,
+      browserSessionId: ctx.sessionId!,
+    });
 
     ctx.status = 302;
     ctx.response.headers.set('Cache-Control', 'no-cache');
@@ -129,7 +131,7 @@ class AuthorizeController extends Controller {
     codeChallengeMethod: 'S256' | 'plain' | undefined
   ) {
 
-    const code = await oauth2Service.generateCodeForUser(
+    const code = await oauth2Service.generateAuthorizationCode(
       oauth2Client,
       ctx.session.user,
       codeChallenge,

--- a/src/oauth2/controller/user-access-token.ts
+++ b/src/oauth2/controller/user-access-token.ts
@@ -21,7 +21,9 @@ class UserAccessTokenController extends Controller {
     if (user.type !== 'user') {
       throw new BadRequest('This API can only be used for principals of type \'user\'');
     }
-    const token = await oauth2Service.generateTokenForUserNoClient(user);
+    const token = await oauth2Service.generateTokenDeveloperToken({
+      principal: user,
+    });
 
     ctx.response.body = {
       access_token: token.accessToken,

--- a/src/oauth2/types.ts
+++ b/src/oauth2/types.ts
@@ -1,30 +1,67 @@
 import { App, User } from '../principal/types';
+import { GrantType } from '../types';
 
 export type OAuth2Token = {
-  // OAuth2 Access token
+
+  /**
+   * OAuth2 Access token
+   */
   accessToken: string;
 
-  // OAuth2 Refresh token
+  /**
+   * OAuth2 Refresh token
+   */
   refreshToken: string;
 
-  // Unix timestamp of when the token expires (in seconds)
+  /**
+   * Unix timestamp of when the token expires (in seconds)
+   */
   accessTokenExpires: number;
 
-  // Unix timestamp of when the token expires (in seconds)
+  /**
+   * Unix timestamp of when the token expires (in seconds)
+   */
   refreshTokenExpires: number;
 
-  // Type of token. Only 'bearer' is supported rn.
+  /**
+   * Type of token. Only 'bearer' is supported rn.
+   */
   tokenType: 'bearer';
 
-  // The user this token belongs to
-  user: App | User;
+  /*
+   * The user or app that this token auhtenticates.
+   */
+  principal: App | User;
 
-  // The OAuth2 client (app) that created this session
+  /*
+   * The OAuth2 client (app) that created this token.
+   */
   clientId: number;
 
-  // If the token was created via a browser-flow, such as implicit or
-  // authorization_code, this will contain the browser session cookie
-  // id.
+  /**
+   * OAuth2 Grant Type used to create this token.
+   */
+  grantType: Exclude<GrantType, 'refresh_token'> | null;
+
+  /**
+   * True if a client_secret was used to generate the token.
+   *
+   * Certain flows (authorization_code, implicit) don't require it but
+   * if a token was generated with a secret, it must also be refreshed
+   * with a secret.
+   */
+  secretUsed: boolean;
+
+  /**
+   * OAuth2 scopes
+   */
+  scope: string[]|null;
+
+  /**
+   * If the token was created via a browser-flow, such as implicit or
+   * authorization_code, this will contain the browser session cookie
+   * id.
+   */
   browserSessionId?: string;
 };
 

--- a/src/one-time-token/controller/exchange.ts
+++ b/src/one-time-token/controller/exchange.ts
@@ -44,7 +44,10 @@ class OneTimeTokenExchangeController extends Controller {
     }
 
     const client = await oauth2ClientService.findByClientId(ctx.request.body.client_id);
-    const oauth2Token = await oauth2Service.generateTokenForUser(client, user);
+    const oauth2Token = await oauth2Service.generateTokenOneTimeToken({
+      client,
+      principal: user,
+    });
 
     ctx.response.body = tokenResponse(oauth2Token);
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,20 @@
+/**
+ * OAuth2 grant types
+ */
+export type GrantType =
+  | 'refresh_token'
+  | 'client_credentials'
+  | 'password'
+  | 'implicit'
+  | 'authorization_code'
+  | 'one-time-token' // a12n-server tokens for things like password reset
+  | 'developer-token'; // User-generated developer token
+
 export type ServerStats = {
   user: number;
   app: number;
   group: number;
   privileges: number;
+  tokensIssued: number;
 }
+


### PR DESCRIPTION
This became a bit bigger than expected, but:

* Refactors the OAuth2 service to have more consistent function signatures.
* Adds token statistics to the oauth2 homepage.
* Stores the 'grant_type' and whether a 'secret' was used in the tokens table.
* We're now storing 'scope' for every token. This OAuth2 feature wasn't really used by this server, but this sets up the first steps for this.
* Fixes a bug related to generating principal uris in the introspection endpoints.
* Has more explicit support for the 2 a12nserver-specific oauth2 flows: "developer tokens" and "one-time-tokens".
* Run sqlite migrations in github actions

Other side-effects of this PR:

* A few step furthers in #405
* Some progress towards OpenID Connect support (scopes are important for this).