### PR TITLE
Scope was largely ignored in authorization_code

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,15 @@
 Changelog
 =========
 
+0.22.1 (????-??-??)
+-------------------
+
+* 'scope' wasn't supported yet correctly in the `authorization_code` and
+  `implicit` flows.
+* Fixed some bugs in the 'active sessions' report, and add columns for
+  `grant_type`, and `scope`.
+
+
 0.22.0 (2022-09-27)
 -------------------
 

--- a/src/db-types.ts
+++ b/src/db-types.ts
@@ -48,11 +48,16 @@ export type Oauth2CodesRecord = {
   id: number;
   client_id: number;
   code: string;
-  user_id: number;
+  principal_id: number;
   code_challenge: string | null;
   code_challenge_method: 'plain' | 'S256' | null;
-  created: number;
+  created_at: number;
   browser_session_id: string | null;
+
+  /**
+   * OAuth2 scopes, space separated
+   */
+  scope: string | null;
 }
 
 export type Oauth2RedirectUrisRecord = {

--- a/src/migrations/20221002160500_auth_code_scopes.ts
+++ b/src/migrations/20221002160500_auth_code_scopes.ts
@@ -1,0 +1,22 @@
+import { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.alterTable('oauth2_codes', table => {
+    table
+      .renameColumn('created', 'created_at')
+      .comment('When the code was issued, unix timestamp');
+    table
+      .renameColumn('user_id', 'principal_id')
+      .comment('User for which the code is issued.');
+    table
+      .string('scope', 1024)
+      .nullable()
+      .comment('OAuth2 scopes, space separated');
+  });
+}
+
+export async function down(knex: Knex): Promise<void> {
+
+  throw new Error('This migration cannot be undone');
+
+}

--- a/src/oauth2/controller/authorize.ts
+++ b/src/oauth2/controller/authorize.ts
@@ -72,8 +72,6 @@ class AuthorizeController extends Controller {
     const codeChallenge = ctx.query.code_challenge;
     const grantType = responseType === 'code' ? 'authorization_code' : 'implicit';
 
-
-
     if (!oauth2Client.allowedGrantTypes.includes(grantType)) {
       throw new UnsupportedGrantType('The current client is not allowed to use the ' + grantType + ' grant_type');
     }
@@ -103,7 +101,7 @@ class AuthorizeController extends Controller {
 
     const token = await oauth2Service.generateTokenImplicit({
       client: oauth2Client,
-      scope: ctx.params.scope?.split(' ') ?? null,
+      scope: ctx.query.scope?.split(' ') ?? null,
       principal: ctx.session.user,
       browserSessionId: ctx.sessionId!,
     });
@@ -131,13 +129,14 @@ class AuthorizeController extends Controller {
     codeChallengeMethod: 'S256' | 'plain' | undefined
   ) {
 
-    const code = await oauth2Service.generateAuthorizationCode(
-      oauth2Client,
-      ctx.session.user,
-      codeChallenge,
-      codeChallengeMethod,
-      ctx.sessionId!,
-    );
+    const code = await oauth2Service.generateAuthorizationCode({
+      client: oauth2Client,
+      principal: ctx.session.user,
+      scope: ctx.query.scope?.split(' ') ?? null,
+      codeChallenge: codeChallenge,
+      codeChallengeMethod: codeChallengeMethod,
+      browserSessionId: ctx.sessionId!,
+    });
 
     ctx.status = 302;
     ctx.response.headers.set('Cache-Control', 'no-cache');

--- a/src/oauth2/controller/token.ts
+++ b/src/oauth2/controller/token.ts
@@ -89,7 +89,6 @@ class TokenController extends Controller {
       client: oauth2Client,
       code: ctx.request.body.code,
       codeVerifier: ctx.request.body.code_verifier,
-      scope: ctx.request.body.scope?.split(' ') ?? null,
       secretUsed,
     });
 


### PR DESCRIPTION
The 'scope' now gets passed along correctly. A lot of this is set up for eventual OpenID Connect support.