### PR TITLE
Keep track of which apps requested which scopes for users

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,7 @@ Changelog
   `grant_type`, and `scope`.
 * Common types, such `User`, `App`, `Group` types have been moved to
   `src/types.ts` for easier access.
+* We're now keeping track of which scopes were granted to which apps per user.
 
 
 0.22.0 (2022-09-27)

--- a/package-lock.json
+++ b/package-lock.json
@@ -523,9 +523,9 @@
       }
     },
     "node_modules/@curveball/browser": {
-      "version": "0.19.3",
-      "resolved": "https://registry.npmjs.org/@curveball/browser/-/browser-0.19.3.tgz",
-      "integrity": "sha512-KUV0xDdJIl57QgTSCHCSOTXa0Y3myRvqhqz+3U44tFDB17oNV0z0o57AlgiMW165njRf9P2iIYTojv6NggG74g==",
+      "version": "0.19.4",
+      "resolved": "https://registry.npmjs.org/@curveball/browser/-/browser-0.19.4.tgz",
+      "integrity": "sha512-ty1HcA7Z/uYWX/l+FL4UOvCfVwS91tBDB8ZR9jxSg787nsuh9BubWtKbejufGsKetbNzYpbIlV4i34GgC9JYPg==",
       "dependencies": {
         "@curveball/static": "^0.3.0",
         "csv-parse": "^5.1.0",
@@ -6984,9 +6984,9 @@
       "requires": {}
     },
     "@curveball/browser": {
-      "version": "0.19.3",
-      "resolved": "https://registry.npmjs.org/@curveball/browser/-/browser-0.19.3.tgz",
-      "integrity": "sha512-KUV0xDdJIl57QgTSCHCSOTXa0Y3myRvqhqz+3U44tFDB17oNV0z0o57AlgiMW165njRf9P2iIYTojv6NggG74g==",
+      "version": "0.19.4",
+      "resolved": "https://registry.npmjs.org/@curveball/browser/-/browser-0.19.4.tgz",
+      "integrity": "sha512-ty1HcA7Z/uYWX/l+FL4UOvCfVwS91tBDB8ZR9jxSg787nsuh9BubWtKbejufGsKetbNzYpbIlV4i34GgC9JYPg==",
       "requires": {
         "@curveball/static": "^0.3.0",
         "csv-parse": "^5.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,6 +53,7 @@
         "@types/qrcode": "^1.4.0",
         "@types/redis": "^2.8.32",
         "@types/sinon": "^10.0.0",
+        "@types/sinon-chai": "^3.2.8",
         "@typescript-eslint/eslint-plugin": "^5.1.0",
         "@typescript-eslint/parser": "^5.1.0",
         "chai": "^4.3.4",
@@ -63,6 +64,7 @@
         "mysql-types-generator": "^1.0.3",
         "nyc": "^15.1.0",
         "sinon": "^14.0.0",
+        "sinon-chai": "^3.7.0",
         "ts-node": "^10.0.0",
         "tsc-watch": "^5.0.3",
         "typescript": "^4.5.4"
@@ -1318,6 +1320,16 @@
       "dev": true,
       "dependencies": {
         "@types/sinonjs__fake-timers": "*"
+      }
+    },
+    "node_modules/@types/sinon-chai": {
+      "version": "3.2.8",
+      "resolved": "https://registry.npmjs.org/@types/sinon-chai/-/sinon-chai-3.2.8.tgz",
+      "integrity": "sha512-d4ImIQbT/rKMG8+AXpmcan5T2/PNeSjrYhvkwet6z0p8kzYtfgA32xzOBlbU0yqJfq+/0Ml805iFoODO0LP5/g==",
+      "dev": true,
+      "dependencies": {
+        "@types/chai": "*",
+        "@types/sinon": "*"
       }
     },
     "node_modules/@types/sinonjs__fake-timers": {
@@ -5787,6 +5799,16 @@
         "url": "https://opencollective.com/sinon"
       }
     },
+    "node_modules/sinon-chai": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-3.7.0.tgz",
+      "integrity": "sha512-mf5NURdUaSdnatJx3uhoBOrY9dtL19fiOtAdT1Azxg3+lNJFiuN0uzaU3xX1LeAfL17kHQhTAJgpsfhbMJMY2g==",
+      "dev": true,
+      "peerDependencies": {
+        "chai": "^4.0.0",
+        "sinon": ">=4.0.0"
+      }
+    },
     "node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -7648,6 +7670,16 @@
       "dev": true,
       "requires": {
         "@types/sinonjs__fake-timers": "*"
+      }
+    },
+    "@types/sinon-chai": {
+      "version": "3.2.8",
+      "resolved": "https://registry.npmjs.org/@types/sinon-chai/-/sinon-chai-3.2.8.tgz",
+      "integrity": "sha512-d4ImIQbT/rKMG8+AXpmcan5T2/PNeSjrYhvkwet6z0p8kzYtfgA32xzOBlbU0yqJfq+/0Ml805iFoODO0LP5/g==",
+      "dev": true,
+      "requires": {
+        "@types/chai": "*",
+        "@types/sinon": "*"
       }
     },
     "@types/sinonjs__fake-timers": {
@@ -10983,6 +11015,13 @@
         "nise": "^5.1.1",
         "supports-color": "^7.2.0"
       }
+    },
+    "sinon-chai": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-3.7.0.tgz",
+      "integrity": "sha512-mf5NURdUaSdnatJx3uhoBOrY9dtL19fiOtAdT1Azxg3+lNJFiuN0uzaU3xX1LeAfL17kHQhTAJgpsfhbMJMY2g==",
+      "dev": true,
+      "requires": {}
     },
     "slash": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "@types/qrcode": "^1.4.0",
     "@types/redis": "^2.8.32",
     "@types/sinon": "^10.0.0",
+    "@types/sinon-chai": "^3.2.8",
     "@typescript-eslint/eslint-plugin": "^5.1.0",
     "@typescript-eslint/parser": "^5.1.0",
     "chai": "^4.3.4",
@@ -65,6 +66,7 @@
     "mysql-types-generator": "^1.0.3",
     "nyc": "^15.1.0",
     "sinon": "^14.0.0",
+    "sinon-chai": "^3.7.0",
     "ts-node": "^10.0.0",
     "tsc-watch": "^5.0.3",
     "typescript": "^4.5.4"

--- a/schemas/user-app-permissions.json
+++ b/schemas/user-app-permissions.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "$id": "https://curveballjs.org/schemas/a12nserver/user-app-permissions.json",
+  "type": "object",
+  "name": "User App Permissions",
+  "description": "This object contains the list of permissions/scopes that the user has granted to an app. The app may act on behalf of the user for these scopes.",
+
+  "required": ["scope", "createdAt", "modifiedAt", "lastUsedAt"],
+  "additionalProperties": false,
+
+  "properties": {
+    "_links": {
+      "description": "HAL Links"
+    },
+    "scope": {
+      "type": "array",
+      "description": "List of scopes that were granted to the app",
+      "items": {
+        "type": "string"
+      }
+    },
+    "createdAt": {
+      "type": "string",
+      "format": "date-time",
+      "description": "The date/time when the user first granted privileges to the app."
+    },
+    "modifiedAt": {
+      "type": "string",
+      "format": "date-time",
+      "description": "The date/time when the list of scopes was last updated."
+    },
+    "lastUsedAt": {
+      "type": ["string", "null"],
+      "format": "date-time",
+      "description": "The last time an access token was generated or refreshed by this app, for this user."
+    }
+  }
+}

--- a/src/db-types.ts
+++ b/src/db-types.ts
@@ -1,3 +1,4 @@
+import 'knex';
 
 declare module 'knex/types/tables' {
 
@@ -12,6 +13,7 @@ interface Tables {
   privileges: PrivilegesRecord;
   reset_password_token: ResetPasswordTokenRecord;
   server_settings: ServerSettingsRecord;
+  user_app_permissions: UserAppPermissionsRecord;
   user_log: UserLogRecord;
   user_passwords: UserPasswordsRecord;
   user_privileges: UserPrivilegesRecord;
@@ -119,6 +121,40 @@ export type ResetPasswordTokenRecord = {
 export type ServerSettingsRecord = {
   setting: string;
   value: string | null;
+}
+
+export type UserAppPermissionsRecord = {
+  id: number;
+
+  /**
+   * Reference to the app / OAuth2 client
+   */
+  app_id: number;
+
+  /**
+   * User / Resource owner
+   */
+  user_id: number;
+
+  /**
+   * Scopes that were requested
+   */
+  scope: string | null;
+
+  /**
+   * When the user first gave permission to the app
+   */
+  created_at: number;
+
+  /**
+   * Last time the set of permissions were changed
+   */
+  modified_at: number;
+
+  /**
+   * Last time this application issued or refreshed an access token
+   */
+  last_used_at: number;
 }
 
 export type UserLogRecord = {

--- a/src/migrations/20221002165500_user_app.ts
+++ b/src/migrations/20221002165500_user_app.ts
@@ -6,9 +6,10 @@ export async function up(knex: Knex): Promise<void> {
     table.integer('app_id').unsigned().notNullable().comment('Reference to the app / OAuth2 client');
     table.integer('user_id').unsigned().notNullable().comment('User / Resource owner');
     table.string('scope', 1024).comment('Scopes that were requested');
-    table.integer('created_at').unsigned().notNullable().comment('When the user first gave permission to the app');
-    table.integer('modified_at').unsigned().notNullable().comment('Last time the set of permissions were changed');
-    table.integer('last_used_at').unsigned().notNullable().comment('Last time this application issued or refreshed an access token');
+    table.bigint('created_at').unsigned().notNullable().comment('When the user first gave permission to the app');
+    table.bigint('modified_at').unsigned().notNullable().comment('Last time the set of permissions were changed');
+    table.bigint('last_used_at').unsigned().nullable().comment('Last time this application issued or refreshed an access token');
+    table.unique(['app_id', 'user_id']);
     table.comment('This table lists the permissions that user have given to apps');
   });
 

--- a/src/migrations/20221002165500_user_app.ts
+++ b/src/migrations/20221002165500_user_app.ts
@@ -1,0 +1,21 @@
+import { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.createTable('user_app_permissions', table => {
+    table.increments('id');
+    table.integer('app_id').unsigned().notNullable().comment('Reference to the app / OAuth2 client');
+    table.integer('user_id').unsigned().notNullable().comment('User / Resource owner');
+    table.string('scope', 1024).comment('Scopes that were requested');
+    table.integer('created_at').unsigned().notNullable().comment('When the user first gave permission to the app');
+    table.integer('modified_at').unsigned().notNullable().comment('Last time the set of permissions were changed');
+    table.integer('last_used_at').unsigned().notNullable().comment('Last time this application issued or refreshed an access token');
+    table.comment('This table lists the permissions that user have given to apps');
+  });
+
+}
+
+export async function down(knex: Knex): Promise<void> {
+
+  await knex.schema.dropTable('user_app_permissions');
+
+}

--- a/src/oauth2/controller/authorize.ts
+++ b/src/oauth2/controller/authorize.ts
@@ -105,7 +105,7 @@ class AuthorizeController extends Controller {
 
   }
 
-  async tokenRedirect(ctx: Context, oauth2Client: OAuth2Client, redirectUri: string, state: string|undefined, scope: string[]|null) {
+  async tokenRedirect(ctx: Context, oauth2Client: OAuth2Client, redirectUri: string, state: string|undefined, scope: string[]) {
 
     const token = await oauth2Service.generateTokenImplicit({
       client: oauth2Client,
@@ -133,7 +133,7 @@ class AuthorizeController extends Controller {
     oauth2Client: OAuth2Client,
     redirectUri: string,
     state: string|undefined,
-    scope: string[] | null,
+    scope: string[],
     codeChallenge: string|undefined,
     codeChallengeMethod: 'S256' | 'plain' | undefined,
   ) {

--- a/src/oauth2/controller/token.ts
+++ b/src/oauth2/controller/token.ts
@@ -61,7 +61,7 @@ class TokenController extends Controller {
 
     const token = await oauth2Service.generateTokenClientCredentials({
       client: oauth2Client,
-      scope: ctx.request.body.scope?.split(' ') ?? null,
+      scope: ctx.request.body.scope?.split(' ') ?? [],
     });
 
     ctx.response.type = 'application/json';

--- a/src/oauth2/jwt.ts
+++ b/src/oauth2/jwt.ts
@@ -16,7 +16,9 @@ export async function generateJWTAccessToken(user: User|App, client: OAuth2Clien
   const jwt = await new SignJWT({
     scope: scopes.join(' '),
   })
-    .setProtectedHeader({alg: 'RS256'})
+    .setProtectedHeader({
+      alg: 'RS256'
+    })
     .setIssuedAt()
     .setIssuer(origin)
     .setAudience(client.app.href)

--- a/src/oauth2/service.ts
+++ b/src/oauth2/service.ts
@@ -85,7 +85,7 @@ export async function getActiveTokens(user: App | User): Promise<OAuth2Token[]> 
 type GenerateTokenImplicitOptions = {
   client: OAuth2Client;
   principal: User;
-  scope: string[] | null;
+  scope: string[];
   browserSessionId: string;
 }
 
@@ -102,7 +102,7 @@ export function generateTokenImplicit(options: GenerateTokenImplicitOptions): Pr
 
 type GenerateTokenClientCredentialsOptions = {
   client: OAuth2Client;
-  scope: string[] | null;
+  scope: string[];
 }
 
 /**
@@ -120,7 +120,7 @@ export function generateTokenClientCredentials(options: GenerateTokenClientCrede
 type GenerateTokenPasswordOptions = {
   client: OAuth2Client;
   principal: User;
-  scope: string[] | null;
+  scope: string[];
 }
 /**
  * Generates a token for the 'implicit' GrantType
@@ -189,7 +189,7 @@ export async function generateTokenAuthorizationCode(options: GenerateTokenAutho
   return generateTokenInternal({
     grantType: 'authorization_code',
     principal: user,
-    scope: codeRecord.scope?.split(' ') || null,
+    scope: codeRecord.scope?.split(' ') || [],
     ...options,
   });
 
@@ -226,7 +226,7 @@ export function generateTokenDeveloperToken(options: GenerateTokenDeveloperToken
     ...options,
     secretUsed: false,
     client,
-    scope: null,
+    scope: [],
   });
 }
 
@@ -242,7 +242,7 @@ export function generateTokenOneTimeToken(options: GenerateTokenOneTimeTokenOpti
     grantType: 'developer-token',
     ...options,
     secretUsed: false,
-    scope: null,
+    scope: [],
   });
 }
 
@@ -258,7 +258,7 @@ type GenerateTokenOptions = {
   grantType: GrantType | null;
   client: OAuth2Client;
   principal: App |User;
-  scope: string[] | null;
+  scope: string[];
   browserSessionId?: string;
   secretUsed: boolean;
 }
@@ -283,7 +283,7 @@ async function generateTokenInternal(options: GenerateTokenOptions): Promise<OAu
       options.principal,
       options.client,
       expirySettings.accessToken,
-      []
+      options.scope,
     );
   } else {
     accessToken = await generateSecretToken();
@@ -440,7 +440,7 @@ export async function revokeToken(token: OAuth2Token): Promise<void> {
 type GenerateAuthorizationCodeOptions = {
   client: OAuth2Client;
   principal: User;
-  scope: string[] | null;
+  scope: string[];
   codeChallenge: string|undefined;
   codeChallengeMethod: CodeChallengeMethod|undefined;
   browserSessionId: string;
@@ -587,7 +587,7 @@ function tokenRecordToModel(token: Oauth2TokensRecord, principal: User | App): O
     grantType,
     secretUsed,
 
-    scope: token.scope?.split(' ') ?? null,
+    scope: token.scope?.split(' ') ?? [],
 
     principal,
     clientId: token.oauth2_client_id,

--- a/src/oauth2/types.ts
+++ b/src/oauth2/types.ts
@@ -54,7 +54,7 @@ export type OAuth2Token = {
   /**
    * OAuth2 scopes
    */
-  scope: string[]|null;
+  scope: string[];
 
   /**
    * If the token was created via a browser-flow, such as implicit or

--- a/src/principal/service.ts
+++ b/src/principal/service.ts
@@ -114,6 +114,36 @@ export async function findByExternalId(externalId: string, type?: PrincipalType)
 }
 
 /**
+ * Find multiple principals.
+ *
+ * This function returns the principals as a map, index by their id.
+ * This is a helper function typically used by other services to find large numbers
+ * of joined principals from other tables fast.
+ *
+ * If any of the ids in the list is duplicated, they are de-duplicated here.
+ * if any of the provided ids are not found, this function will error.
+ */
+export async function findMany(ids: number[]): Promise<Map<number,Principal>> {
+
+  const records = await db('principals')
+    .select()
+    .whereIn('id', ids);
+
+  const result = new Map<number, Principal>(records.map(
+    record => [record.id, recordToModel(record)]
+  ));
+
+  for (const id of ids) {
+    if (!result.has(id)) {
+      throw new NotFound(`Principal with ${id} not found`);
+    }
+  }
+
+  return result;
+
+}
+
+/**
  * Returns true if more than 1 principal exists in the system.
  *
  * If there are 0 principals, this puts a12nserver in setup mode, which allows a

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -42,6 +42,8 @@ import settings from './settings/controller';
 import user from './user/controller/item';
 import userAccessToken from './oauth2/controller/user-access-token';
 import userActiveSessions from './oauth2/controller/active-sessions';
+import userAppPermissionItem from './user-app-permissions/controller/user-item';
+import userAppPermissionCollection from './user-app-permissions/controller/user-collection';
 import userByHref from './user/controller/by-href';
 import userEdit from './user/controller/edit';
 import userEditPrivileges from './user/controller/privileges';
@@ -107,6 +109,8 @@ const routes = [
   router('/user/:id/one-time-token', oneTimeToken),
   router('/user/:id/access-token', userAccessToken),
   router('/user/:id/sessions', userActiveSessions),
+  router('/user/:id/app-permission', userAppPermissionCollection),
+  router('/user/:id/app-permission/:appId', userAppPermissionItem),
 
   router('/change-password', changePassword),
   router('/reset-password', resetPassword),

--- a/src/user-app-permissions/controller/user-collection.ts
+++ b/src/user-app-permissions/controller/user-collection.ts
@@ -1,0 +1,28 @@
+import Controller from '@curveball/controller';
+import { Context } from '@curveball/core';
+import * as privilegeService from '../../privilege/service';
+import * as hal from '../formats/hal';
+import { Forbidden } from '@curveball/http-errors';
+import * as principalService from '../../principal/service';
+import * as userAppPermissionService from '../service';
+
+class UserAppPermissionsCollection extends Controller {
+
+  async get(ctx: Context) {
+
+    const principal = await principalService.findByExternalId(ctx.params.id, 'user');
+    if (ctx.auth.equals(principal) && !await privilegeService.hasPrivilege(ctx, 'admin')) {
+      throw new Forbidden('You can only use this API for yourself yourself, or if you have \'admin\' privileges');
+    }
+
+    const appPermissions = await userAppPermissionService.findByUser(principal);
+    ctx.response.body = hal.collection(
+      principal,
+      appPermissions
+    );
+
+  }
+
+}
+
+export default new UserAppPermissionsCollection();

--- a/src/user-app-permissions/controller/user-collection.ts
+++ b/src/user-app-permissions/controller/user-collection.ts
@@ -12,7 +12,7 @@ class UserAppPermissionsCollection extends Controller {
 
     const principal = await principalService.findByExternalId(ctx.params.id, 'user');
     if (ctx.auth.equals(principal) && !await privilegeService.hasPrivilege(ctx, 'admin')) {
-      throw new Forbidden('You can only use this API for yourself yourself, or if you have \'admin\' privileges');
+      throw new Forbidden('You can only use this API for yourself, or if you have \'admin\' privileges');
     }
 
     const appPermissions = await userAppPermissionService.findByUser(principal);

--- a/src/user-app-permissions/controller/user-item.ts
+++ b/src/user-app-permissions/controller/user-item.ts
@@ -12,7 +12,7 @@ class UserAppPermissionsItem extends Controller {
 
     const user = await principalService.findByExternalId(ctx.params.id, 'user');
     if (ctx.auth.equals(user) && !await privilegeService.hasPrivilege(ctx, 'admin')) {
-      throw new Forbidden('You can only use this API for yourself yourself, or if you have \'admin\' privileges');
+      throw new Forbidden('You can only use this API for yourself, or if you have \'admin\' privileges');
     }
     const app = await principalService.findByExternalId(ctx.params.appId, 'app');
 

--- a/src/user-app-permissions/controller/user-item.ts
+++ b/src/user-app-permissions/controller/user-item.ts
@@ -14,7 +14,7 @@ class UserAppPermissionsItem extends Controller {
     if (ctx.auth.equals(user) && !await privilegeService.hasPrivilege(ctx, 'admin')) {
       throw new Forbidden('You can only use this API for yourself yourself, or if you have \'admin\' privileges');
     }
-    const app = await principalService.findById(+ctx.params.appId, 'app');
+    const app = await principalService.findByExternalId(ctx.params.appId, 'app');
 
     const appPermission = await userAppPermissionService.findByUserAndApp(
       user,

--- a/src/user-app-permissions/controller/user-item.ts
+++ b/src/user-app-permissions/controller/user-item.ts
@@ -1,0 +1,31 @@
+import Controller from '@curveball/controller';
+import { Context } from '@curveball/core';
+import * as privilegeService from '../../privilege/service';
+import * as hal from '../formats/hal';
+import { Forbidden } from '@curveball/http-errors';
+import * as principalService from '../../principal/service';
+import * as userAppPermissionService from '../service';
+
+class UserAppPermissionsItem extends Controller {
+
+  async get(ctx: Context) {
+
+    const user = await principalService.findByExternalId(ctx.params.id, 'user');
+    if (ctx.auth.equals(user) && !await privilegeService.hasPrivilege(ctx, 'admin')) {
+      throw new Forbidden('You can only use this API for yourself yourself, or if you have \'admin\' privileges');
+    }
+    const app = await principalService.findById(+ctx.params.appId, 'app');
+
+    const appPermission = await userAppPermissionService.findByUserAndApp(
+      user,
+      app
+    );
+    ctx.response.body = hal.item(
+      appPermission
+    );
+
+  }
+
+}
+
+export default new UserAppPermissionsItem();

--- a/src/user-app-permissions/formats/hal.ts
+++ b/src/user-app-permissions/formats/hal.ts
@@ -18,7 +18,7 @@ export function collection(user: User, userAppPermissions: UserAppPermission[]):
       item: userAppPermissions.map( item => {
         return {
           title: item.app.nickname,
-          href: `${user.href}/app-permission/${item.app.id}`
+          href: `${user.href}/app-permission/${item.app.externalId}`
         };
       })
     },
@@ -37,7 +37,7 @@ export function item(userAppPermissions: UserAppPermission): HalResource {
   return {
     _links: {
       self: {
-        href: `${user.href}/app-permissions/${app.id}`,
+        href: `${user.href}/app-permissions/${app.externalId}`,
         title: `${app.nickname} permissions for ${user.nickname}`,
       },
       user: {

--- a/src/user-app-permissions/formats/hal.ts
+++ b/src/user-app-permissions/formats/hal.ts
@@ -1,0 +1,63 @@
+import { UserAppPermission } from '../types';
+import { HalResource } from 'hal-types';
+import { User } from '../../types';
+
+
+export function collection(user: User, userAppPermissions: UserAppPermission[]): HalResource {
+
+  return {
+    _links: {
+      self: {
+        href: `${user.href}/app-permissions`,
+        title: 'App Permissions',
+      },
+      principal: {
+        href: user.href,
+        title: user.nickname,
+      },
+      item: userAppPermissions.map( item => {
+        return {
+          title: item.app.nickname,
+          href: `${user.href}/app-permission/${item.app.id}`
+        };
+      })
+    },
+    description: 'This collection contains the list of applications that can act on behalf of this user',
+    total: userAppPermissions.length,
+
+  };
+
+}
+
+export function item(userAppPermissions: UserAppPermission): HalResource {
+
+  const user = userAppPermissions.user;
+  const app = userAppPermissions.app;
+
+  return {
+    _links: {
+      self: {
+        href: `${user.href}/app-permissions/${app.id}`,
+        title: `${app.nickname} permissions for ${user.nickname}`,
+      },
+      user: {
+        href: user.href,
+        title: user.nickname,
+      },
+      app: {
+        href: app.href,
+        title: app.nickname,
+      },
+      collection: {
+        href: `${user.href}/app-permission`,
+        title: 'List of apps for this user'
+      }
+    },
+    scope: userAppPermissions.scope,
+    createdAt: userAppPermissions.createdAt.toISOString(),
+    modifiedAt: userAppPermissions.modifiedAt.toISOString(),
+    lastUsedAt: userAppPermissions.lastUsedAt?.toISOString() ?? null,
+
+  };
+
+}

--- a/src/user-app-permissions/formats/hal.ts
+++ b/src/user-app-permissions/formats/hal.ts
@@ -51,7 +51,11 @@ export function item(userAppPermissions: UserAppPermission): HalResource {
       collection: {
         href: `${user.href}/app-permission`,
         title: 'List of apps for this user'
-      }
+      },
+      describedby: {
+        href: 'https://curveballjs.org/schemas/a12nserver/user-app-permissions.json',
+        type: 'application/schema+json'
+      },
     },
     scope: userAppPermissions.scope,
     createdAt: userAppPermissions.createdAt.toISOString(),

--- a/src/user-app-permissions/service.ts
+++ b/src/user-app-permissions/service.ts
@@ -1,0 +1,120 @@
+import db from '../database';
+import { App, User } from '../types';
+import { UserAppPermission } from './types';
+import * as principalService from '../principal/service';
+import { UserAppPermissionsRecord } from 'knex/types/tables';
+import { NotFound } from '@curveball/http-errors';
+
+/**
+ * This function will set the permissions an app has on behalf of a user.
+ *
+ * If permissions already existed, the new list of permissions will be merged
+ * with the old ones.
+ */
+export async function setPermissions(app: App, user: User, scope: string[]): Promise<void> {
+
+  await db.transaction(async trx => {
+
+    const userAppPermission = await trx('user_app_permissions')
+      .first()
+      .where({
+        user_id: user.id,
+        app_id: app.id
+      })
+      .forUpdate();
+
+    if (!userAppPermission) {
+      await trx('user_app_permissions').insert({
+        app_id: app.id,
+        user_id: user.id,
+        scope: scope.length === 0 ? null : scope.join(' '),
+        created_at: Date.now(),
+        modified_at: Date.now(),
+      });
+    } else {
+      const newScopes = new Set<string>([
+        ...scope,
+        ...(userAppPermission.scope ? userAppPermission.scope.split(' ') : []),
+      ]);
+
+      const newScopeStr = Array.from(newScopes).sort().join(' ');
+
+      if (newScopeStr !== userAppPermission.scope) {
+        await trx('user_app_permissions').update({
+          scope: newScopes.size === 0 ? null : Array.from(newScopes).join(' '),
+          modified_at: Date.now(),
+        });
+      }
+    }
+
+  });
+
+}
+
+/**
+ * Returns all the apps the given user has granted permissions to
+ */
+export async function findByUser(user: User): Promise<UserAppPermission[]> {
+
+  const records = await db('user_app_permissions')
+    .select()
+    .where({user_id: user.id});
+
+  const apps = await principalService.findMany(records.map(record => record.app_id)) as Map<number, App>;
+
+  return records.map( record => recordToModel(
+    record,
+    user,
+    apps.get(record.app_id)!
+  ));
+
+}
+
+/**
+ * Returns all the apps the given user has granted permissions to
+ */
+export async function findByUserAndApp(user: User, app: App): Promise<UserAppPermission> {
+
+  const record = await db('user_app_permissions')
+    .first()
+    .where({
+      user_id: user.id,
+      app_id: app.id,
+    });
+
+  if (!record) throw new NotFound(`User has not granted permission to app: ${app.href}`);
+
+  return recordToModel(
+    record,
+    user,
+    app
+  );
+
+}
+
+/**
+ * When an app generates an access token for a user, we update the lastUsedAt property.
+ */
+export async function updateLastUse(user: User, app: App): Promise<void> {
+
+  await db('user_app_permissions')
+    .update({last_used_at: Date.now()})
+    .where({
+      user_id: user.id,
+      app_id: app.id
+    });
+
+}
+
+function recordToModel(record: UserAppPermissionsRecord, user: User, app: App): UserAppPermission {
+
+  return {
+    app,
+    user,
+    scope: record.scope ? record.scope.split(' ') : [],
+    createdAt: new Date(record.created_at),
+    modifiedAt: new Date(record.modified_at),
+    lastUsedAt: record.last_used_at === null ? null : new Date(record.last_used_at),
+  };
+
+}

--- a/src/user-app-permissions/types.ts
+++ b/src/user-app-permissions/types.ts
@@ -1,0 +1,41 @@
+import { User, App } from '../types';
+
+/**
+ * This type represents the set of permissions that an app is allowed to use
+ * by a user.
+ *
+ * This can contain things like 'email', enabling an app to access a users'
+ * email, but it may also concrete privileges.
+ */
+export type UserAppPermission = {
+
+  /**
+   * Reference to the app.
+   */
+  app: App;
+
+  /**
+   * User / Resource owner
+   */
+  user: User;
+
+  /**
+   * Scopes/privileges that the app has access to.
+   */
+  scope: string[];
+
+  /**
+   * When the user first gave permission to the app
+   */
+  createdAt: Date;
+
+  /**
+   * Last time the set of permissions were changed
+   */
+  modifiedAt: Date;
+
+  /**
+   * Last time this application issued or refreshed an access token
+   */
+  lastUsedAt: Date | null;
+}

--- a/src/user/controller/edit.ts
+++ b/src/user/controller/edit.ts
@@ -9,7 +9,7 @@ class UserEditController extends Controller {
 
   async get(ctx: Context) {
 
-    const user = await principalService.findByExternalId(ctx.params.id);
+    const user = await principalService.findByExternalId(ctx.params.id, 'user');
 
     if (!await privilegeService.hasPrivilege(ctx, 'admin')) {
       throw new Forbidden('Only users with the "admin" privilege use this endpoint');

--- a/src/user/formats/hal.ts
+++ b/src/user/formats/hal.ts
@@ -44,6 +44,7 @@ export function item(user: User, privileges: PrivilegeMap, hasControl: boolean, 
         href: group.href,
         title: group.nickname,
       })),
+
       'describedby': {
         href: 'https://curveballjs.org/schemas/a12nserver/user.json',
         type: 'application/schema+json',
@@ -74,6 +75,10 @@ export function item(user: User, privileges: PrivilegeMap, hasControl: boolean, 
       href: `${user.href}/sessions`,
       title: 'Active user sessions'
     };
+    hal._links['app-permission-collection'] = {
+      href: `${user.href}/app-permission`,
+      title: 'App Permissions',
+    };
   }
   if (isAdmin) {
     hal._links['password'] = {
@@ -99,7 +104,7 @@ export function item(user: User, privileges: PrivilegeMap, hasControl: boolean, 
 
 }
 
-export function edit(user: Principal): HalResource {
+export function edit(user: User): HalResource {
   return {
     _links: {
       self: {

--- a/test/oauth2/controller/authorize.ts
+++ b/test/oauth2/controller/authorize.ts
@@ -6,6 +6,7 @@ import { URLSearchParams } from 'url';
 import { MemoryRequest, Context, MemoryResponse } from '@curveball/core';
 import * as chai from 'chai';
 import * as chaiAsPromised from 'chai-as-promised';
+import * as  sinonChai from 'sinon-chai';
 import * as sinon from 'sinon';
 
 import { InvalidRequest } from '../../../src/oauth2/errors';
@@ -13,12 +14,16 @@ import * as oauth2Service from '../../../src/oauth2/service';
 import * as oauth2ClientService from '../../../src/oauth2-client/service';
 import * as principalService from '../../../src/principal/service';
 import * as userService from '../../../src/user/service';
+import * as userAppPermissionService from '../../../src/user-app-permissions/service';
 import * as serverSettings from '../../../src/server-settings';
 import { User, App } from '../../../src/types';
 import { OAuth2Client } from '../../../src/oauth2-client/types';
 import authorize from '../../../src/oauth2/controller/authorize';
 
+
 chai.use(chaiAsPromised);
+chai.use(sinonChai);
+
 const expect = chai.expect;
 
 describe('AuthorizeController', () => {
@@ -68,6 +73,7 @@ describe('AuthorizeController', () => {
     sandbox.stub(userService, 'validatePassword').returns(Promise.resolve(true));
     sandbox.stub(userService, 'hasTotp').returns(Promise.resolve(false));
     sandbox.stub(serverSettings, 'getSetting').returns(true);
+    sandbox.stub(userAppPermissionService, 'setPermissions').returns(Promise.resolve(undefined));
   });
 
   afterEach(() => {
@@ -96,9 +102,15 @@ describe('AuthorizeController', () => {
       };
 
       await authorize.get(context);
-      expect(codeRedirectMock.calledOnceWithExactly(
-        context, oauth2Client, 'redirect-uri', 'state', 'challenge-code', 'S256'
-      )).to.be.true;
+      expect(codeRedirectMock).to.have.been.calledWithExactly(
+        context,
+        oauth2Client,
+        'redirect-uri',
+        'state',
+        [],
+        'challenge-code',
+        'S256'
+      );
     });
 
     it('should set challenge code method to plain if not provided', async() => {
@@ -111,9 +123,15 @@ describe('AuthorizeController', () => {
       };
 
       await authorize.get(context);
-      expect(codeRedirectMock.calledOnceWithExactly(
-        context, oauth2Client, 'redirect-uri', 'state', 'challenge-code', 'plain'
-      )).to.be.true;
+      expect(codeRedirectMock).to.have.been.calledWithExactly(
+        context,
+        oauth2Client,
+        'redirect-uri',
+        'state',
+        [],
+        'challenge-code',
+        'plain'
+      );
     });
 
     it('should pass valid parameters and call code redirect without PKCE', async() => {
@@ -127,9 +145,15 @@ describe('AuthorizeController', () => {
       };
 
       await authorize.get(context);
-      expect(codeRedirectMock.calledOnceWithExactly(
-        context, oauth2Client, 'redirect-uri', 'state', undefined, undefined
-      )).to.be.true;
+      expect(codeRedirectMock).to.have.been.calledWithExactly(
+        context,
+        oauth2Client,
+        'redirect-uri',
+        'state',
+        [],
+        undefined,
+        undefined,
+      );
     });
 
     it('should fail code challenge validation', async() => {


### PR DESCRIPTION
This enables us in the future to create the concept of a third-party apps. These apps will explicitly have to request the user if they are willing to give permission to certain scopes.

Right now all scopes are auto-granted, because all apps are considered 'first party' and trusted.

This is also a step towards OpenID Connect support.

Fixes #435 