### PR TITLE
'Add privilege' action

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -12,6 +12,8 @@ Changelog
   `src/types.ts` for easier access.
 * We're now keeping track of which scopes were granted to which apps per user.
 * Support for RFC 9068: A standard format for JWT OAuth2 Access Tokens.
+* Centralize CSRF token handling (for old browsers).
+* Added a new 'add privilege' action, which is helpful for API clients.
 
 
 0.22.0 (2022-09-27)

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@curveball/accesslog": "^0.3.0",
         "@curveball/bodyparser": "^0.5.0",
-        "@curveball/browser": "^0.19.2",
+        "@curveball/browser": "^0.19.6",
         "@curveball/controller": "^0.4.0",
         "@curveball/core": "^0.20.0",
         "@curveball/cors": "^0.2.0",
@@ -525,9 +525,9 @@
       }
     },
     "node_modules/@curveball/browser": {
-      "version": "0.19.4",
-      "resolved": "https://registry.npmjs.org/@curveball/browser/-/browser-0.19.4.tgz",
-      "integrity": "sha512-ty1HcA7Z/uYWX/l+FL4UOvCfVwS91tBDB8ZR9jxSg787nsuh9BubWtKbejufGsKetbNzYpbIlV4i34GgC9JYPg==",
+      "version": "0.19.6",
+      "resolved": "https://registry.npmjs.org/@curveball/browser/-/browser-0.19.6.tgz",
+      "integrity": "sha512-YTuqSy8Pv/sye/KcMK1Yxay6hBxdmyiQORv798pHlHlGrvEauCxLA3xXEWaiACKzCPSa9B+enWhH1a2ASw3ZDg==",
       "dependencies": {
         "@curveball/static": "^0.3.0",
         "csv-parse": "^5.1.0",
@@ -7006,9 +7006,9 @@
       "requires": {}
     },
     "@curveball/browser": {
-      "version": "0.19.4",
-      "resolved": "https://registry.npmjs.org/@curveball/browser/-/browser-0.19.4.tgz",
-      "integrity": "sha512-ty1HcA7Z/uYWX/l+FL4UOvCfVwS91tBDB8ZR9jxSg787nsuh9BubWtKbejufGsKetbNzYpbIlV4i34GgC9JYPg==",
+      "version": "0.19.6",
+      "resolved": "https://registry.npmjs.org/@curveball/browser/-/browser-0.19.6.tgz",
+      "integrity": "sha512-YTuqSy8Pv/sye/KcMK1Yxay6hBxdmyiQORv798pHlHlGrvEauCxLA3xXEWaiACKzCPSa9B+enWhH1a2ASw3ZDg==",
       "requires": {
         "@curveball/static": "^0.3.0",
         "csv-parse": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
   "dependencies": {
     "@curveball/accesslog": "^0.3.0",
     "@curveball/bodyparser": "^0.5.0",
-    "@curveball/browser": "^0.19.2",
+    "@curveball/browser": "^0.19.6",
     "@curveball/controller": "^0.4.0",
     "@curveball/core": "^0.20.0",
     "@curveball/cors": "^0.2.0",

--- a/schemas/principal-patch-privilege.json
+++ b/schemas/principal-patch-privilege.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "$id": "https://curveballjs.org/schemas/a12nserver/principal-patch-privilege.json",
+  "type": "object",
+  "description": "This object is a request body for patching a principal's ACL.",
+
+  "required": ["action", "privilege", "resource"],
+
+  "properties": {
+    "action": {
+      "const": "add",
+      "description": "Indicates that a privilege was added"
+    },
+    "privilege": {
+      "type": "string",
+      "description": "The name of the privilege, for example 'write' or 'read'"
+    },
+    "resource": {
+      "description": "The resource on which the user is receiving the privilege for. This should be a URI or '*'",
+      "oneOf": [
+        {
+          "const": "*"
+        },
+        {
+          "type": "string",
+          "format": "uri"
+        }
+      ]
+    }
+  },
+  "additionalProperties": false
+}

--- a/src/privilege/formats/hal.ts
+++ b/src/privilege/formats/hal.ts
@@ -1,25 +1,23 @@
 import { Privilege } from '../types';
+import { HalResource } from 'hal-types';
 
-export function collection(privileges: Privilege[]) {
+export function collection(privileges: Privilege[]): HalResource {
 
-  const hal: any = {
+  return {
     _links: {
       self: { href: '/privilege' },
-      item: [],
+      item: privileges.map(privilege => ({
+        href: '/privilege/' + privilege.privilege,
+        title: privilege.description
+      })),
     },
+    total: privileges.length,
   };
 
-  for (const privilege of privileges) {
-    hal._links.item.push({
-      href: '/privilege/' + privilege.privilege,
-      title: privilege.description
-    });
-  }
-  return hal;
 }
 
-export function item(privilege: Privilege) {
-  const hal: any = {
+export function item(privilege: Privilege): HalResource {
+  return {
     _links: {
       self: {href: '/privilege/' + privilege.privilege},
       collection: {href: '/privilege', title: 'Privilege Collection'}
@@ -27,7 +25,4 @@ export function item(privilege: Privilege) {
     privilege: privilege.privilege,
     description: privilege.description
   };
-
-
-  return hal;
 }

--- a/src/user/controller/privileges.ts
+++ b/src/user/controller/privileges.ts
@@ -11,9 +11,9 @@ type PolicyForm = {
   policyBody: string;
 }
 type PrincipalPatchPrivilege = {
-  action: 'add',
-  resource: '*' | string,
-  privilege: string
+  action: 'add';
+  resource: '*' | string;
+  privilege: string;
 }
 
 class UserEditPrivilegesController extends Controller {

--- a/src/user/controller/privileges.ts
+++ b/src/user/controller/privileges.ts
@@ -10,19 +10,26 @@ import * as principalService from '../../principal/service';
 type PolicyForm = {
   policyBody: string;
 }
+type PrincipalPatchPrivilege = {
+  action: 'add',
+  resource: '*' | string,
+  privilege: string
+}
 
 class UserEditPrivilegesController extends Controller {
 
   async get(ctx: Context) {
 
     const user = await principalService.findByExternalId(ctx.params.id);
-    const privileges = await privilegeService.getImmediatePrivilegesForPrincipal(user);
+    const userPrivileges = await privilegeService.getImmediatePrivilegesForPrincipal(user);
+    const privileges = await privilegeService.findPrivileges();
 
     await privilegeService.hasPrivilege(ctx, 'admin');
 
     ctx.response.body = hal.editPrivileges(
       user,
-      privileges
+      userPrivileges,
+      privileges.map( privilege => privilege.privilege ),
     );
 
   }
@@ -31,21 +38,50 @@ class UserEditPrivilegesController extends Controller {
 
     const { policyBody } = ctx.request.body;
 
-    const user = await principalService.findByExternalId(ctx.params.id);
+    const principal = await principalService.findByExternalId(ctx.params.id);
     await privilegeService.hasPrivilege(ctx, 'admin');
 
     try {
       const policy = JSON.parse(policyBody) as PrivilegeMap;
 
-      await privilegeService.replacePrivilegeForUser(user, policy);
+      await privilegeService.replacePrivilegeForUser(principal, policy);
     } catch (err: any) {
       throw new BadRequest(err);
     }
 
-    ctx.redirect(303, `/user/${user.id}`);
+    ctx.redirect(303, principal.href);
 
   }
 
+
+  async patch(ctx: Context) {
+
+    ctx.request.validate<PrincipalPatchPrivilege>('https://curveballjs.org/schemas/a12nserver/principal-patch-privilege.json');
+    const principal = await principalService.findByExternalId(ctx.params.id);
+    await privilegeService.hasPrivilege(ctx, 'admin');
+
+    await privilegeService.addPrivilegeForUser(
+      principal,
+      ctx.request.body.privilege,
+      ctx.request.body.resource,
+    );
+
+    ctx.status = 200;
+    ctx.response.body = {
+      _links: {
+        principal: {
+          href: principal.href,
+          title: principal.nickname,
+        },
+        up: {
+          href: `${principal.href}/edit/privileges`,
+          title: 'Back to privileges',
+        }
+      },
+      title: 'Privileges updated',
+    };
+
+  }
 }
 
 export default new UserEditPrivilegesController();

--- a/src/user/formats/hal.ts
+++ b/src/user/formats/hal.ts
@@ -151,20 +151,21 @@ export function edit(user: User): HalResource {
   };
 }
 
-export function editPrivileges(user: Principal, privileges: PrivilegeMap): HalResource {
+export function editPrivileges(principal: Principal, userPrivileges: PrivilegeMap, privileges: string[]): HalResource {
   return {
     _links: {
       self: {
-        href: `${user.href}/edit/privileges`,
+        href: `${principal.href}/edit/privileges`,
+        title: `Edit privileges for ${principal.nickname}`,
       },
       up: {
-        href: user.href,
+        href: principal.href,
         title: 'Cancel',
       },
     },
     _templates: {
-      default: {
-        title: `Edit privilege policy for ${user.nickname}`,
+      edit: {
+        title: `Edit privilege policy for ${principal.nickname}`,
         method: 'POST',
         contentType: 'application/x-www-form-urlencoded',
         properties: [
@@ -174,8 +175,36 @@ export function editPrivileges(user: Principal, privileges: PrivilegeMap): HalRe
             type: 'textarea',
             cols: 100,
             rows: 20,
-            value: JSON.stringify(privileges, undefined, 2),
+            value: JSON.stringify(userPrivileges, undefined, 2),
           },
+        ],
+      },
+      add: {
+        title: 'Add a single privilege',
+        method: 'PATCH',
+        contentType: 'application/json',
+        target: `${principal.href}/edit/privileges`,
+        properties: [
+          {
+            name: 'privilege',
+            prompt: 'Privilege',
+            required: true,
+            options: {
+              inline: privileges
+            }
+          },
+          {
+            name: 'resource',
+            prompt: 'Resource (uri)',
+            required: true,
+            type: 'url',
+            placeHolder: 'https://my-api/resource/foo',
+          },
+          {
+            name: 'action',
+            type: 'hidden',
+            value: 'add'
+          }
         ],
       },
     },


### PR DESCRIPTION
action can be called by the user in the HAL browser, or an API client.

It's a lot easier to use this by API clients compared to the 'replace
all privileges' action that exists right now.