### PR TITLE
Fix Redis session bugs

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -24,6 +24,8 @@ Changelog
   remembered.
 * The 'password' flow now also tracks apps that are granted access to user
   accounts
+* When using the Redis session backend, CSRF tokens would not get stored
+  correctly, causing some browser operations to fail.
 
 
 0.23.1 (2023-03-29)

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@curveball/links": "^0.3.0",
         "@curveball/problem": "^0.5.0",
         "@curveball/router": "^0.6.0",
-        "@curveball/session": "^0.9.0",
+        "@curveball/session": "^0.10.0",
         "@curveball/session-redis": "^0.5.0",
         "@curveball/validator": "^0.10.0",
         "@simplewebauthn/browser": "^5.2.1",
@@ -740,9 +740,9 @@
       }
     },
     "node_modules/@curveball/session": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@curveball/session/-/session-0.9.0.tgz",
-      "integrity": "sha512-EetkOscvPNQj6vhzUFCiRODXTh+YSRPzbSxeVe/L3mvQBP12G2KKUgTEWcUBg69sMtVGc7lkkQAr0CV0wcXlLg==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@curveball/session/-/session-0.10.0.tgz",
+      "integrity": "sha512-lAXn79uyvSTfMWlEZf2HrJeo8p2eKBSgIXOZvcOUIIMuNWuDrM9fATVeEN/z9yaYg4sb8NqgyEucSE2aOpRUew==",
       "dependencies": {
         "cookie": "^0.5.0"
       },

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "@curveball/links": "^0.3.0",
     "@curveball/problem": "^0.5.0",
     "@curveball/router": "^0.6.0",
-    "@curveball/session": "^0.9.0",
+    "@curveball/session": "^0.10.0",
     "@curveball/session-redis": "^0.5.0",
     "@curveball/validator": "^0.10.0",
     "@simplewebauthn/browser": "^5.2.1",

--- a/src/main-mw.ts
+++ b/src/main-mw.ts
@@ -38,13 +38,6 @@ export default function (): Middleware {
   }
 
   middlewares.push(
-    browser({
-      title: 'a12n-server',
-      stylesheets: [
-        '/assets/extra.css'
-      ],
-    }),
-    problem(),
     session({
       store: process.env.REDIS_HOST ? new RedisStore({
         prefix: 'A12N-session',
@@ -57,6 +50,14 @@ export default function (): Middleware {
       cookieName: 'A12N',
       expiry: 60 * 60 * 24 * 7,
     }),
+    browser({
+      title: 'a12n-server',
+      stylesheets: [
+        '/assets/extra.css'
+      ],
+    }),
+    problem(),
+
     login(),
     bodyParser(),
     csrf(),


### PR DESCRIPTION
When using the Redis session backend, CSRF tokens would not get stored correctly, causing some browser operations to fail.