### PR TITLE
Internal privilege improvements

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,12 +4,12 @@ Changelog
 0.24.1 (????-??-??)
 -------------------
 
-* Added two privileges for one-time-token use: `a12n:one-time-token:generate` and
-  `a12n-one-time-token:exchange`, these both required the `admin` privilege. Theres
-  no bc break here as the original `admin` privilege still covers these new ones.
+* Added two privileges for one-time-token use: `a12n:one-time-token:generate`
+  and `a12n-one-time-token:exchange`, these both required the `admin`
+  privilege. Theres no bc break here as the original `admin` privilege still
+  covers these new ones.
 * It wasn't possible to see a full principal even if a user had
   `a12n:principal:list` privilege.
-
 
 
 0.24.0 (2023-11-09)

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,17 @@
 Changelog
 =========
 
+0.24.1 (????-??-??)
+-------------------
+
+* Added two privileges for one-time-token use: `a12n:one-time-token:generate` and
+  `a12n-one-time-token:exchange`, these both required the `admin` privilege. Theres
+  no bc break here as the original `admin` privilege still covers these new ones.
+* It wasn't possible to see a full principal even if a user had
+  `a12n:principal:list` privilege.
+
+
+
 0.24.0 (2023-11-09)
 -------------------
 

--- a/src/middleware/login.ts
+++ b/src/middleware/login.ts
@@ -103,6 +103,7 @@ export default function(): Middleware {
       }
       // We are logged in!
       ctx.auth = new AuthHelper(token.principal);
+      ctx.privileges = await privilegeService.get(ctx.auth.principal!);
 
       return next();
 

--- a/src/migrations/20231109012626_new_privileges.ts
+++ b/src/migrations/20231109012626_new_privileges.ts
@@ -1,0 +1,19 @@
+import { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  await knex('privileges')
+    .insert({privilege: 'a12n:one-time-token:generate', description: 'Create a token for an arbitrary user, this token grants full access to this account.'});
+
+  await knex('privileges')
+    .insert({privilege: 'a12n:one-time-token:exchange', description: 'Exchange a one-time-token for a OAuth2 access token.'});
+}
+
+
+export async function down(knex: Knex): Promise<void> {
+
+  await knex('privileges')
+    .delete()
+    .whereIn('privileges', ['a12n:one-time-token:generate', 'a12n:one-time-token:exchange']);
+
+}
+

--- a/src/one-time-token/controller/exchange.ts
+++ b/src/one-time-token/controller/exchange.ts
@@ -20,7 +20,7 @@ class OneTimeTokenExchangeController extends Controller {
 
   async post(ctx: Context<OtteRequest>) {
 
-    ctx.privileges.require('admin');
+    ctx.privileges.require('a12n:one-time-token:exchange');
     const principalService = new PrincipalService(ctx.privileges);
 
     if (!ctx.request.body.token) {

--- a/src/one-time-token/controller/generate.ts
+++ b/src/one-time-token/controller/generate.ts
@@ -9,7 +9,7 @@ class OneTimeTokenController extends Controller {
 
   async post(ctx: Context<any>) {
 
-    ctx.privileges.require('admin');
+    ctx.privileges.require('a12n:one-time-token:generate');
 
     const principalService = new PrincipalService(ctx.privileges);
     const user = await principalService.findByExternalId(ctx.params.id, 'user');

--- a/src/principal/service.ts
+++ b/src/principal/service.ts
@@ -345,7 +345,7 @@ export class PrincipalService {
    */
   async findGroupsForPrincipal(principal: Principal): Promise<Group[]> {
 
-    this.privileges.require('admin');
+    this.privileges.require('a12n:principals:list');
     const result = await db('principals')
       .select('principals.*')
       .innerJoin('group_members', { 'principals.id': 'group_members.group_id'})

--- a/src/privilege/types.ts
+++ b/src/privilege/types.ts
@@ -16,7 +16,10 @@ export type PrivilegeEntry = {
 }
 
 export type InternalPrivilege =
-  'admin' |
-  'a12n:principals:list' |
-  'a12n:principals:create' |
-  'a12n:principals:update';
+  | 'admin'
+  | 'a12n:principals:list'
+  | 'a12n:principals:create'
+  | 'a12n:principals:update'
+  | 'a12n:one-time-token:generate'
+  | 'a12n:one-time-token:exchange'
+


### PR DESCRIPTION
* Added two privileges for one-time-token use: `a12n:one-time-token:generate` and `a12n-one-time-token:exchange`, these both required the `admin` privilege. There's no bc break here as the original `admin` privilege still covers these new ones.
* It wasn't possible to see a full principal even if a user has the `a12n:principal:list` privilege.