### PR TITLE
adding public schema in the SEARCH_PATH configuration for pg config

### DIFF
--- a/src/database.ts
+++ b/src/database.ts
@@ -95,6 +95,7 @@ export function getSettings(): Knex.Config {
     searchPath = [
       connection.user as string,
       connection.database as string,
+      'public',
     ];
 
 


### PR DESCRIPTION
related to the issue [#494 ](https://github.com/curveball/a12n-server/issues/494)

I'm not sure this is best way to solve the issue but by adding the 'public' string in the search path, the knex migration works

![2024-03-25 14_24_24-](https://github.com/curveball/a12n-server/assets/10908634/10501850-859e-4117-99bb-e3718a362337)
