### PR TITLE
Fix(csrf): Send csrf token for the `/change-password` path

### DIFF
--- a/src/changepassword/controller.ts
+++ b/src/changepassword/controller.ts
@@ -10,9 +10,9 @@ class ChangePasswordController extends Controller {
 
   async get(ctx: Context) {
 
+    const csrfToken = await ctx.getCsrf();
     ctx.response.type = 'text/html';
-    ctx.response.body = changePasswordForm(ctx.query.msg, ctx.query.error);
-
+    ctx.response.body = changePasswordForm(ctx.query.msg, ctx.query.error, csrfToken);
   }
 
   async post(ctx: Context<any>) {

--- a/src/changepassword/formats/html.ts
+++ b/src/changepassword/formats/html.ts
@@ -1,12 +1,13 @@
 import { render } from '../../templates.js';
 
-export function changePasswordForm(msg: string, error: string) {
+export function changePasswordForm(msg: string, error: string, csrfToken: string) {
 
   return render('changepassword', {
     title: 'Change Password',
     msg: msg,
     error: error,
     action: '/change-password',
+    csrfToken: csrfToken,
   });
 
 }

--- a/src/middleware/csrf.ts
+++ b/src/middleware/csrf.ts
@@ -10,7 +10,7 @@ const safePaths = [
 
 export default function(): Middleware {
 
-  return (ctx, next) => {
+  return async (ctx, next) => {
 
     /**
      * There's 2 ways a user might be authenticated, via a session cookie or
@@ -21,7 +21,12 @@ export default function(): Middleware {
     if (!ctx.session.user) return next();
 
     if (!safeMethods.includes(ctx.method) && !safePaths.includes(ctx.path)) {
-      ctx.validateCsrf();
+      if(ctx.path === '/change-password'){
+        ctx.validateCsrf(await ctx.getCsrf());
+      }
+      else{
+        ctx.validateCsrf();
+      }
     }
 
     delete ctx.request.body?.['csrf-token'];

--- a/src/middleware/csrf.ts
+++ b/src/middleware/csrf.ts
@@ -10,7 +10,7 @@ const safePaths = [
 
 export default function(): Middleware {
 
-  return async (ctx, next) => {
+  return (ctx, next) => {
 
     /**
      * There's 2 ways a user might be authenticated, via a session cookie or
@@ -21,12 +21,7 @@ export default function(): Middleware {
     if (!ctx.session.user) return next();
 
     if (!safeMethods.includes(ctx.method) && !safePaths.includes(ctx.path)) {
-      if(ctx.path === '/change-password'){
-        ctx.validateCsrf(await ctx.getCsrf());
-      }
-      else{
-        ctx.validateCsrf();
-      }
+      ctx.validateCsrf();
     }
 
     delete ctx.request.body?.['csrf-token'];

--- a/templates/changepassword.hbs
+++ b/templates/changepassword.hbs
@@ -26,6 +26,8 @@
     <p class="form-options"><a href="/">Cancel</a></p>
   </fieldset>
 
+  <input type="hidden" name="csrf-token" value="{{ csrfToken }}" />
+
   {{#each hiddenFields}}
   <input type="hidden" name="{{@key}}" value="{{this}}" />
   {{/each}}


### PR DESCRIPTION
For #534.

A `csrf-token` already exists on `ctx.session`. But we need to pass it to `validateCsrf()`. 