### PR TITLE
Generating arbitrary access-tokens is now behind a special privilege.

### DIFF
--- a/src/migrations/20241027202400_new_privileges.ts
+++ b/src/migrations/20241027202400_new_privileges.ts
@@ -1,0 +1,18 @@
+import { Knex } from 'knex';
+
+const privilege = 'a12n:access-token:generate';
+
+export async function up(knex: Knex): Promise<void> {
+  await knex('privileges')
+    .insert({privilege, description: 'Allows a user to create a valid access-token for another user without consent. This privilege allows full control of other accounts and should never be given to third parties.'});
+
+}
+
+export async function down(knex: Knex): Promise<void> {
+
+  await knex('privileges')
+    .delete()
+    .whereIn('privileges', [privilege]);
+
+}
+

--- a/src/oauth2/controller/user-access-token.ts
+++ b/src/oauth2/controller/user-access-token.ts
@@ -14,8 +14,8 @@ class UserAccessTokenController extends Controller {
     const principalService = new PrincipalService(ctx.privileges);
     const user = await principalService.findByExternalId(ctx.params.id, 'user');
 
-    if (ctx.auth.equals(user) && !ctx.privileges.has('admin')) {
-      throw new Forbidden('You can only generate OAuth2 access tokens for yourself with this endpoint (unless you have the \'admin\' privilege (which you haven\'t))');
+    if (!ctx.auth.equals(user) && !ctx.privileges.has('a12n:access-token:generate')) {
+      throw new Forbidden('You can only generate OAuth2 access tokens for yourself with this endpoint (unless you have the \'a12n:access-token:generate\' privilege (which you haven\'t))');
     }
 
     const token = await oauth2Service.generateTokenDeveloperToken({

--- a/src/privilege/types.ts
+++ b/src/privilege/types.ts
@@ -22,4 +22,5 @@ export type InternalPrivilege =
   | 'a12n:principals:update'
   | 'a12n:one-time-token:generate'
   | 'a12n:one-time-token:exchange'
-  | 'a12n:user:change-password';
+  | 'a12n:user:change-password'
+  | 'a12n:access-token:generate';

--- a/src/server-settings.ts
+++ b/src/server-settings.ts
@@ -256,7 +256,7 @@ export function requireSetting<T extends keyof Settings>(setting: T): Settings[T
     } else {
       msg+'There is literally no way to actually do this, and this is a bug. DM me for a prize.';
     }
-    throw msg;
+    throw new Error(msg);
   }
 
   return value;

--- a/src/user/formats/hal.ts
+++ b/src/user/formats/hal.ts
@@ -79,7 +79,7 @@ export function item(user: User, privileges: PrivilegeMap, hasControl: boolean, 
       hints: {
         allow: ['POST'],
       }
-    }
+    };
 
   }
 

--- a/src/user/formats/hal.ts
+++ b/src/user/formats/hal.ts
@@ -72,16 +72,23 @@ export function item(user: User, privileges: PrivilegeMap, hasControl: boolean, 
     };
   }
 
+  if (hasControl || currentUserPrivileges.has('a12n:access-token:generate', user.href)) {
+    hal._links['access-token'] = {
+      href: `${user.href}/access-token`,
+      title: 'Generate an access token for this user.',
+      hints: {
+        allow: ['POST'],
+      }
+    }
+
+  }
+
   if (hasControl) {
     hal.hasPassword = hasPassword;
 
     hal._links['auth-factor-collection'] = {
       href: `${user.href}/auth-factor`,
       title: 'List of authentication methods / authentication factors for a user',
-    };
-    hal._links['access-token'] = {
-      href: `${user.href}/access-token`,
-      title: 'Generate an access token for this user.',
     };
     hal._links['active-sessions'] = {
       href: `${user.href}/sessions`,


### PR DESCRIPTION
Before this change it required the 'admin' privilege. Users that had
'admin' automatically inherit all privileges so this is not a BC break.
