### PR TITLE
Refactor logger

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,6 @@ docker-run:
 	docker run -it --rm --name $(DOCKER_IMAGE_NAME)-01 $(DOCKER_IMAGE_NAME)
 
 test:
-	ls -lA node_modules/.bin
 	npx tsx --test ${TEST_FILES}
 
 lint:

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+0.26.8 (????-??-??)
+-------------------
+
+* Refactored logging system. Less ugly now with fewer enums!
+
+
 0.26.7 (2024-11-07)
 -------------------
 

--- a/src/changepassword/controller.ts
+++ b/src/changepassword/controller.ts
@@ -1,7 +1,6 @@
 import Controller from '@curveball/controller';
 import { Context } from '@curveball/core';
-import log from '../log/service.js';
-import { EventType } from '../log/types.js';
+import { getLoggerFromContext } from '../log/service.js';
 import * as UserService from '../user/service.js';
 import { User } from '../types.js';
 import { changePasswordForm } from './formats/html.js';
@@ -45,7 +44,8 @@ class ChangePasswordController extends Controller {
     ctx.session = {
       user: user,
     };
-    log(EventType.changePasswordSuccess, ctx);
+    const log = getLoggerFromContext(ctx);
+    await log('change-password-success');
     ctx.status = 303;
     ctx.response.headers.set('Location', '/');
 

--- a/src/log/formats/csv.ts
+++ b/src/log/formats/csv.ts
@@ -1,4 +1,4 @@
-import { eventTypeString, LogEntry } from '../types.js';
+import { LogEntry } from '../types.js';
 import { stringify } from 'csv-stringify/sync';
 
 export default function csv(log: LogEntry[]): string {
@@ -14,7 +14,6 @@ export default function csv(log: LogEntry[]): string {
     },
     cast: {
       date: (value) => value.toISOString(),
-      number: (value) => eventTypeString.get(value)!,
     }
   });
 

--- a/src/log/service.ts
+++ b/src/log/service.ts
@@ -1,48 +1,37 @@
 import { Context } from '@curveball/core';
 import db from '../database.js';
 import { Principal } from '../types.js';
-import { EventType, LogEntry } from './types.js';
+import { EventType, LogEntry, reverseEventTypeMap, UserEventLogger, eventTypeMap } from './types.js';
 import geoip from 'geoip-lite';
 import { UserLogRecord } from 'knex/types/tables.js';
 
-export function log(eventType: EventType, ctx: Context): Promise<void>;
-export function log(eventType: EventType, ip: string|null, userId: number, userAgent: string|null): Promise<void>;
-export function log(eventType: EventType, ip: string|null, userId: number): Promise<void>;
-export async function log(
-  eventType: EventType,
-  arg1: string | Context | null,
-  arg2?: number,
-  arg3?: string|null
-) {
+export function getLoggerFromContext(ctx: Context, principal?: Principal|number): UserEventLogger {
+  return (et: EventType) => addLogEntry(
+    et,
+    ctx.ip() ?? '',
+    principal ?? ctx.session.user?.id,
+    ctx.request.headers.get('User-Agent')
+  );
+}
 
-  if (isContext(arg1)) {
+export function getLogger(principal: Principal | number, ip: string|null, userAgent: string|null) {
 
-    if (process.env.NODE_ENV === 'dev') {
-      if (!arg1.session.user?.id) {
-        throw new Error('[DEBUG] user_log is invoked with a context that didn\'t have a user. This log entry will be ignored');
-      }
-    }
-
-    await addLogEntry(
-      eventType,
-      arg1.ip() ?? '',
-      arg1.session.user?.id ?? null,
-      arg1.request.headers.get('User-Agent'),
-    );
-  } else {
-    await addLogEntry(eventType, arg1 ?? '', arg2!, arg3 ?? '');
-  }
+  return (et: EventType) => addLogEntry(
+    et,
+    ip ?? '',
+    typeof principal === 'number' ? principal : principal.id,
+    userAgent
+  );
 
 }
 
-export default log;
 
 export async function addLogEntry(eventType: EventType, ip: string, userId: number, userAgent: string|null): Promise<void> {
 
   await db('user_log').insert({
     user_id: userId,
     time: Math.floor(Date.now() / 1000),
-    event_type: eventType,
+    event_type: eventTypeMap[eventType],
     ip: ip,
     user_agent: userAgent,
     country: ip ? getCountryByIp(ip) : null,
@@ -55,21 +44,16 @@ export async function findByUser(user: Principal): Promise<LogEntry[]> {
   const result = await db('user_log')
     .select('*')
     .where({user_id: user.id});
+
   return result.map( (row: UserLogRecord) => {
     return {
       time: new Date(row.time * 1000),
       ip: row.ip,
-      eventType: row.event_type,
+      eventType: reverseEventTypeMap.get(row.event_type)!,
       userAgent: row.user_agent,
       country: row.country
     };
   });
-
-}
-
-function isContext(ctx: any): ctx is Context {
-
-  return (ctx as Context).ip !== undefined;
 
 }
 

--- a/src/log/types.ts
+++ b/src/log/types.ts
@@ -1,21 +1,40 @@
-export enum EventType {
-  loginSuccess = 1,
-  loginFailed = 2,
-  totpFailed = 3,
-  changePasswordSuccess = 4,
-  resetPasswordRequest = 5,
-  resetPasswordSuccess = 6,
-  loginFailedInactive = 7,
-  webAuthnFailed = 8,
-  tokenRevoked = 9,
-  loginFailedNotVerified = 10,
+export const eventTypeMap = {
 
-  oauth2BadRedirect = 11,
-  generateAccessToken = 12,
+  'login-success': 1,
+  'login-failed': 2,
 
-  accountLocked = 13, // Logged at the time the account is locked
-  loginFailedAccountLocked = 14, // Logged when a login attempt is made on a locked account
-}
+  // Account was deactivated by an admin
+  'login-failed-inactive': 8,
+
+  // A credential used by a user to log in (like an email address) was not
+  // verified. The credential must be verifiedd before it can be used.
+  'login-failed-notverified': 10,
+
+  // A user tried to log in using an account that was previously locked
+  'login-failed-account-locked': 14,
+
+  'totp-failed': 3,
+  'webauthn-failed': 8,
+
+  'change-password-success': 5,
+
+  'reset-password-request': 6,
+  'reset-password-success': 7,
+
+  'token-revoked': 8,
+  'oauth2-badredirect': 11,
+  'generate-access-token': 12,
+
+  // Triggered when an account is locked down due to a security trigger, such
+  // as getting a password wrong 5 times.
+  'account-locked': 13,
+} as const;
+
+export type EventType = keyof typeof eventTypeMap;
+
+export const reverseEventTypeMap = new Map<number, EventType>(
+   (Object.entries(eventTypeMap).map( ([k,v]): [number, EventType] => [v,k as EventType]))
+);
 
 export type LogEntry = {
   time: Date;
@@ -25,18 +44,10 @@ export type LogEntry = {
   country: string|null;
 };
 
-export const eventTypeString = new Map<EventType, string>([
-  [EventType.loginSuccess,          'login-success'],
-  [EventType.loginFailed,           'login-failed'],
-  [EventType.totpFailed,            'totp-failed'],
-  [EventType.webAuthnFailed,        'webauthn-failed'],
-  [EventType.changePasswordSuccess, 'change-password-success'],
-  [EventType.resetPasswordRequest,  'reset-password-request'],
-  [EventType.resetPasswordSuccess,  'reset-password-success'],
-  [EventType.loginFailedInactive,   'login-failed-inactive'],
-  [EventType.loginFailedNotVerified,'login-failed-notverified'],
-  [EventType.tokenRevoked,          'token-revoked'],
-  [EventType.oauth2BadRedirect,     'oauth2-badredirect'],
-  [EventType.accountLocked, 'account-locked'],
-  [EventType.loginFailedAccountLocked, 'login-failed-account-locked'],
-]);
+/**
+ * A function that logs user security event.
+ *
+ * This function is initialized to be associated to a specific user,
+ * making it easy to pass around.
+ */
+export type UserEventLogger = (eventType: EventType) => Promise<void>

--- a/src/log/types.ts
+++ b/src/log/types.ts
@@ -33,7 +33,7 @@ export const eventTypeMap = {
 export type EventType = keyof typeof eventTypeMap;
 
 export const reverseEventTypeMap = new Map<number, EventType>(
-   (Object.entries(eventTypeMap).map( ([k,v]): [number, EventType] => [v,k as EventType]))
+  (Object.entries(eventTypeMap).map( ([k,v]): [number, EventType] => [v,k as EventType]))
 );
 
 export type LogEntry = {

--- a/src/login/service.ts
+++ b/src/login/service.ts
@@ -6,6 +6,7 @@ import { OAuth2Code } from '../oauth2/types.js';
 import * as services from '../services.js';
 import { getSessionStore } from '../session-store.js';
 import { AppClient, Principal, PrincipalIdentity, User } from '../types.js';
+import { getLoggerFromContext } from '../log/service.js';
 
 type ChallengeRequest = AuthorizationChallengeRequest;
 
@@ -230,7 +231,8 @@ async function challengeUsernamePassword(session: LoginSession, username: string
     );
   }
 
-  const { success, errorMessage } = await services.user.validateUserCredentials(user, password, ctx);
+  const log = getLoggerFromContext(ctx, user);
+  const { success, errorMessage } = await services.user.validateUserCredentials(user, password, log);
   if (!success && errorMessage) {
     throw new A12nLoginChallengeError(
       session,

--- a/src/oauth2/controller/authorize.ts
+++ b/src/oauth2/controller/authorize.ts
@@ -7,8 +7,7 @@ import { InvalidClient, InvalidRequest, UnsupportedGrantType } from '../errors.j
 import * as oauth2Service from '../service.js';
 import { CodeChallengeMethod } from '../types.js';
 import { AppClient } from '../../types.js';
-import log from '../../log/service.js';
-import { EventType } from '../../log/types.js';
+import { getLoggerFromContext } from '../../log/service.js';
 import { findByClientId } from '../../app-client/service.js';
 import * as userAppPermissions from '../../user-app-permissions/service.js';
 import { generateJWTIDToken } from '../jwt.js';
@@ -51,10 +50,11 @@ class AuthorizeController extends Controller {
       throw new UnsupportedGrantType('The current client is not allowed to use the ' + grantType + ' grant_type');
     }
 
+    const log = getLoggerFromContext(ctx);
     try {
       await oauth2Service.requireRedirectUri(oauth2Client, params.redirectUri);
     } catch (err) {
-      await log(EventType.oauth2BadRedirect, ctx);
+      await log('oauth2-badredirect');
       throw err;
     }
 

--- a/src/oauth2/controller/revoke.ts
+++ b/src/oauth2/controller/revoke.ts
@@ -1,7 +1,6 @@
 import Controller from '@curveball/controller';
 import { Context } from '@curveball/core';
-import log from '../../log/service.js';
-import { EventType } from '../../log/types.js';
+import { getLoggerFromContext } from '../../log/service.js';
 import { revokeByAccessRefreshToken } from '../service.js';
 import { AppClient } from '../../types.js';
 import {
@@ -26,7 +25,8 @@ class RevokeController extends Controller {
 
     await revokeByAccessRefreshToken(oauth2Client, token);
 
-    log(EventType.tokenRevoked, ctx);
+    const log = getLoggerFromContext(ctx);
+    await log('token-revoked');
 
     ctx.status = 200;
 

--- a/src/oauth2/controller/token.ts
+++ b/src/oauth2/controller/token.ts
@@ -5,8 +5,7 @@ import {
   getAppClientFromBasicAuth,
   getAppClientFromBody,
 } from '../../app-client/service.js';
-import log from '../../log/service.js';
-import { EventType } from '../../log/types.js';
+import { getLoggerFromContext } from '../../log/service.js';
 import * as principalIdentityService from '../../principal-identity/service.js';
 import { PrincipalService } from '../../principal/service.js';
 import { AppClient, User } from '../../types.js';
@@ -126,27 +125,18 @@ class TokenController extends Controller {
       throw new InvalidGrant('Unknown username or password');
     }
 
+    const log = getLoggerFromContext(ctx, user);
     if (!user.active) {
-      await log(
-        EventType.loginFailedInactive,
-        ctx.ip(),
-        user.id,
-        ctx.request.headers.get('User-Agent')!
-      );
+      await log('login-failed-inactive');
       throw new InvalidGrant('User Inactive');
     }
 
-    const { success, errorMessage } = await userService.validateUserCredentials(user, ctx.request.body.password, ctx);
+    const { success, errorMessage } = await userService.validateUserCredentials(user, ctx.request.body.password, log);
     if (!success && errorMessage) {
       throw new InvalidGrant(errorMessage);
     }
 
-    await log(
-      EventType.loginSuccess,
-      ctx.ip(),
-      user.id,
-      ctx.request.headers.get('User-Agent')!
-    );
+    await log('login-success');
 
     const scope: string[] = ctx.request.body.scope?.split(' ') ?? [];
 

--- a/src/oauth2/controller/user-access-token.ts
+++ b/src/oauth2/controller/user-access-token.ts
@@ -2,8 +2,7 @@ import Controller from '@curveball/controller';
 import { Context } from '@curveball/core';
 import { Forbidden } from '@curveball/http-errors';
 
-import log from '../../log/service.js';
-import { EventType } from '../../log/types.js';
+import { getLoggerFromContext } from '../../log/service.js';
 import { PrincipalService } from '../../principal/service.js';
 import * as oauth2Service from '../service.js';
 import { tokenResponse } from '../formats/json.js';
@@ -26,7 +25,8 @@ class UserAccessTokenController extends Controller {
     },
     );
     ctx.response.body = tokenResponse(token);
-    log(EventType.generateAccessToken, ctx.ip()!, user.id, ctx.request.headers.get('User-Agent'));
+    const log = getLoggerFromContext(ctx, user);
+    await log('generate-access-token');
 
   }
 

--- a/src/reset-password/controller/request.ts
+++ b/src/reset-password/controller/request.ts
@@ -1,9 +1,9 @@
 import Controller from '@curveball/controller';
 import { Context } from '@curveball/core';
 import { NotFound, BadRequest } from '@curveball/http-errors';
-import { EventType } from '../../log/types.js';
 import { resetPasswordRequestForm } from '../formats/html.js';
 import * as services from '../../services.js';
+import { getLoggerFromContext } from '../../log/service.js';
 
 /**
  * This controller is used for requesting change password when the user forgot the password.
@@ -47,7 +47,8 @@ class ResetPasswordRequestController extends Controller {
       throw new BadRequest('This endpoint can only be called for principals of type \'user\'.');
     }
     await services.resetPassword.sendResetPasswordEmail(user, identity);
-    await services.log.log(EventType.resetPasswordRequest, ctx.ip()!, user.id);
+    const log = getLoggerFromContext(ctx, user);
+    await log('reset-password-request');
 
     ctx.redirect(303, '/reset-password?msg=Password+reset+request+submitted.+Please+check+your+email+for+further+instructions.');
   }

--- a/src/reset-password/controller/reset-password.ts
+++ b/src/reset-password/controller/reset-password.ts
@@ -1,8 +1,7 @@
 import Controller from '@curveball/controller';
 import { Context } from '@curveball/core';
 import { Forbidden } from '@curveball/http-errors';
-import log from '../../log/service.js';
-import { EventType } from '../../log/types.js';
+import { getLoggerFromContext } from '../../log/service.js';
 import * as UserService from '../../user/service.js';
 import { User } from '../../types.js';
 import { resetPasswordForm } from '../formats/redirect.js';
@@ -45,8 +44,11 @@ class ResetPasswordController extends Controller {
 
     await UserService.updatePassword(user, resetNewPassword);
 
-    delete ctx.session.resetPasswordUser;
-    log(EventType.resetPasswordSuccess, ctx.ip()!, user.id);
+    delete ctx.session.resetPasswordUser
+
+    const log = getLoggerFromContext(ctx, user);
+    await log('reset-password-success');
+
     ctx.status = 303;
     ctx.response.headers.set('Location', '/login?msg=Your+new+password+has+been+saved');
 

--- a/src/reset-password/controller/reset-password.ts
+++ b/src/reset-password/controller/reset-password.ts
@@ -44,7 +44,7 @@ class ResetPasswordController extends Controller {
 
     await UserService.updatePassword(user, resetNewPassword);
 
-    delete ctx.session.resetPasswordUser
+    delete ctx.session.resetPasswordUser;
 
     const log = getLoggerFromContext(ctx, user);
     await log('reset-password-success');

--- a/test/log/formats/cvs.ts
+++ b/test/log/formats/cvs.ts
@@ -1,28 +1,28 @@
 import { expect } from 'chai';
 import { describe, it } from 'node:test';
 
-import { EventType } from '../../../src/log/types.js';
 import csv from '../../../src/log/formats/csv.js';
+import { LogEntry } from '../../../src/log/types.js';
 
 describe('csv', () => {
   it('should return formatted log string', () => {
-    const log = [
+    const log: LogEntry[] = [
       {
         time: new Date(0),
         ip: '127.0.0.1',
-        eventType: EventType.loginSuccess,
+        eventType: 'login-success',
         userAgent: 'User Agent',
         country: null,
       },{
         time: new Date(1),
         ip: '127.0.0.1',
-        eventType: EventType.loginFailedInactive,
+        eventType: 'login-failed-inactive',
         userAgent: 'User, Agent',
         country: 'ca',
       },{
         time: new Date(2),
         ip: '127.0.0.1',
-        eventType: EventType.changePasswordSuccess,
+        eventType: 'change-password-success',
         userAgent: 'User Agent"',
         country: 'ca',
       }


### PR DESCRIPTION
Logging was quite repetative, used enums (yuck) and also just looked
ugly. This makes it a bit cleaner and also separates instantiating the
logger from doing the actual logging, which lessens the need for passing
`ctx` around.
