### PR TITLE
Fix code scanning alert no. 4: Incomplete string escaping or encoding

### DIFF
--- a/src/home/controller.ts
+++ b/src/home/controller.ts
@@ -21,7 +21,7 @@ class HomeController extends Controller {
     ctx.response.headers.append('Link', [
       '</>; rel="alternate"; type="application/hal+json"',
       '</logout>; rel="logout"',
-      `<${user.href}>; rel="authenticated-as" title="${user.nickname.replace('"','')}"`,
+      `<${user.href}>; rel="authenticated-as" title="${user.nickname.replace(/"/g, '')}"`,
     ]);
     ctx.response.body = markdown(VERSION, user, isAdmin, stats);
 


### PR DESCRIPTION
Fixes [https://github.com/curveball/a12n-server/security/code-scanning/4](https://github.com/curveball/a12n-server/security/code-scanning/4)

To fix the problem, we should ensure that all occurrences of the double-quote character in `user.nickname` are replaced. This can be achieved by using a regular expression with the global flag (`g`). Additionally, it is a good practice to use a well-tested sanitization library to handle such cases, but for simplicity, we will use the regular expression approach here.

We will modify the `replace` method on line 24 to use a regular expression with the global flag to replace all occurrences of the double-quote character.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
