### PR TITLE
Split email verification error states

### DIFF
--- a/src/login/challenge/email-verification.ts
+++ b/src/login/challenge/email-verification.ts
@@ -81,7 +81,7 @@ export class LoginChallengeEmailVerification extends AbstractLoginChallenge<Emai
     await services.principalIdentity.sendVerificationRequest(identity, this.ip);
     throw new A12nLoginChallengeError(
       `An email has been sent to ${identity.uri.slice(7)} with a code to verify your identity.`,
-      'email_verification_code_invalid',
+      'email_not_verified',
       {
         censored_email: censor(identity.uri)
       }


### PR DESCRIPTION
Changes:
- Fixed EmailVerification challenge to use correct error codes
- Initial challenge now uses `email_not_verified`
- `email_verification_code_invalid` is now only used when an invalid otp code is submitted