### PR TITLE
Workaround for bad authjs encoding of colons in secrets.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+0.29.0 (????-??-??)
+-------------------
+
+* Workaround for authjs incorrectly encoding colon in Basic Auth with
+  percent-encoding.
+
+
 0.28.5 (2025-01-30)
 -------------------
 

--- a/src/app-client/service.ts
+++ b/src/app-client/service.ts
@@ -100,6 +100,9 @@ export async function getAppClientFromBasicAuth(ctx: Context): Promise<AppClient
       throw e;
     }
   }
+  // Some broken clients urlencode ":" so this is a workaround.
+  basicAuth[1] = basicAuth[1].replace(/%3A/ig, ':');
+
   if (!await validateSecret(oauth2Client, basicAuth[1])) {
     throw new Unauthorized('Client id or secret incorrect', 'Basic');
   }


### PR DESCRIPTION
There's no reason to do so, but there's no harm in supporting this to reduce friction.