### PR TITLE
fix(package.json): adds `@curveball/static` as dependency on `package.json`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@curveball/problem": "^1.0.0",
         "@curveball/router": "^2.0.0",
         "@curveball/session": "^1.0.0",
+        "@curveball/static": "^1.0.0",
         "@curveball/validator": "^1.0.0",
         "@simplewebauthn/server": "^10.0.0",
         "@types/debug": "^4.1.12",
@@ -288,7 +289,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@curveball/static/-/static-1.0.0.tgz",
       "integrity": "sha512-Ih27a4zttvlEn64uIjpG/zyPn69Ew98VbEMQuegd5ly4tdnz/w8jGieBdcqrSNJ2EhfRGyMqI1/VH1c4dT0h4g==",
-      "license": "MIT",
       "dependencies": {
         "mime-types": "^2.1.29"
       },

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "@curveball/problem": "^1.0.0",
     "@curveball/router": "^2.0.0",
     "@curveball/session": "^1.0.0",
+    "@curveball/static": "^1.0.0",
     "@curveball/validator": "^1.0.0",
     "@simplewebauthn/server": "^10.0.0",
     "@types/debug": "^4.1.12",


### PR DESCRIPTION
# Changes


When I run `pnpm install` and then `pnpm run build` I get the following error:
```
> make build

./node_modules/.bin/tsc
src/routes.ts:2:22 - error TS2307: Cannot find module '@curveball/static' or its corresponding type declarations.

2 import staticMw from '@curveball/static';
                       ~~~~~~~~~~~~~~~~~~~


Found 1 error in src/routes.ts:2

make: *** [dist/build] Error 2
 ELIFECYCLE  Command failed with exit code 2.
```

If `@curveball/a12n-server` is installed with `npm` `@curveball/static` is in the `package-lock.json`, but this won't resolve in `pnpm-lock.yaml` in a workspace.

This PR makes the dependency available on `package.json` so those using pnpm will be able to build the package.

so it will resolve on `pnpm install`