### PR TITLE
fix(env.defaults): remove trailing slash from `CURVEBALL_ORIGIN`

### DIFF
--- a/.env.defaults
+++ b/.env.defaults
@@ -12,7 +12,7 @@ KEEP_ALIVE_TIMEOUT_MS=
 # Public URL. This must be the URL that users will use to access a12nserver.
 # If this is not provided or incorrect, this will result in the server not
 # functioning correctly.
-CURVEBALL_ORIGIN="http://localhost:8531/"
+CURVEBALL_ORIGIN="http://localhost:8531"
 
 # If the server is running behind a proxy that supports `X-Forwarded-For`, you
 # can set CURVEBALL_TRUSTPROXY to "1" to get better reporting of ip addresses


### PR DESCRIPTION
# Changes

fix: removes trailing slash from `.env.defaults` `CURVEBALL_ORIGIN` so that they don't end up in JSON uris

![Pasted_Image_2025-02-03__8_12 AM](https://github.com/user-attachments/assets/91037825-27bf-49ee-bce3-8df97d935c81)
