### PR TITLE
Developer tokens.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -25,6 +25,7 @@ Changelog
 * Force users to go through login process after changing their password. Before
   this change a change-password token was enough to complete login, but this
   could allow a user to circumvent other authentication factors such as TOTP.
+* Added a small HAL form for easily obtaining developer access tokens.
 
 
 0.28.5 (2025-01-30)

--- a/src/oauth2/controller/user-access-token.ts
+++ b/src/oauth2/controller/user-access-token.ts
@@ -40,7 +40,7 @@ class UserAccessTokenController extends Controller {
           ],
         }
       }
-    }
+    };
 
   }
 

--- a/src/oauth2/controller/user-access-token.ts
+++ b/src/oauth2/controller/user-access-token.ts
@@ -7,7 +7,42 @@ import { PrincipalService } from '../../principal/service.js';
 import * as oauth2Service from '../service.js';
 import { tokenResponse } from '../formats/json.js';
 
+/**
+ * The /user/x/access-token endpoint is used to generate one-off access
+ * tokens for already authenticated users. This can be useful for
+ * quick testing or debugging.
+ *
+ * They're also called 'developer tokens' in the codebase.
+ */
 class UserAccessTokenController extends Controller {
+
+  async get(ctx: Context) {
+
+    const principalService = new PrincipalService(ctx.privileges);
+    const user = await principalService.findByExternalId(ctx.params.id, 'user');
+
+    if (!ctx.auth.equals(user) && !ctx.privileges.has('a12n:access-token:generate')) {
+      throw new Forbidden('You can only generate OAuth2 access tokens for yourself with this endpoint (unless you have the \'a12n:access-token:generate\' privilege (which you haven\'t))');
+    }
+
+    ctx.response.body = {
+      _templates: {
+        'get-access-token': {
+          method: 'POST',
+          href: ctx.path,
+          title: 'Generate access token',
+          properties: [
+            {
+              name: 'scope',
+              type: 'text',
+              description: 'Space-separated list of scopes',
+            },
+          ],
+        }
+      }
+    }
+
+  }
 
   async post(ctx: Context<any>) {
 
@@ -22,8 +57,7 @@ class UserAccessTokenController extends Controller {
       principal: user,
       scope: ctx.request.body?.scope?.split(' '),
       client: ctx.auth.appClient ?? undefined,
-    },
-    );
+    });
     ctx.response.body = tokenResponse(token);
     const log = getLoggerFromContext(ctx, user);
     await log('generate-access-token');


### PR DESCRIPTION
This PR adds a small form at /user/id/access-token that lets a developer
quickly get an OAuth2 access token for testing purposes.

Generally this is only useful for getting tokens if you are already
auhtenticated in the browser.
