### PR TITLE
Added a 'me' endpoint for quick access to the current user

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -26,6 +26,8 @@ Changelog
   this change a change-password token was enough to complete login, but this
   could allow a user to circumvent other authentication factors such as TOTP.
 * Added a small HAL form for easily obtaining developer access tokens.
+* Added a `/me` endpoint that always redirects to the currently authenticated
+  user or app.
 
 
 0.28.5 (2025-01-30)

--- a/src/principal/controller/me.ts
+++ b/src/principal/controller/me.ts
@@ -1,0 +1,18 @@
+import { Controller } from '@curveball/controller';
+import { Context } from '@curveball/core';
+import { Unauthorized } from '@curveball/http-errors';
+
+class MeController extends Controller {
+
+  get(ctx: Context) {
+
+    if (ctx.auth.principal === null) {
+      throw new Unauthorized('You need to be logged in to access this endpoint');
+    }
+    ctx.redirect(ctx.auth.principal.href);
+
+  }
+
+}
+
+export default new MeController();

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -21,6 +21,7 @@ import login from './login/controller/login.js';
 import loginMfa from './login/controller/mfa.js';
 import loginWebAuthn from './mfa/webauthn/controller/login.js';
 import logout from './logout/controller.js';
+import me from './principal/controller/me.js';
 import oauth2Authorize from './oauth2/controller/authorize.js';
 import oauth2AuthorizationChallenge from './login/controller/authorization-challenge.js';
 import oauth2ErrorHandler from './oauth2/oauth2-error-handler.js';
@@ -90,6 +91,7 @@ const routes = [
   router('/login/mfa/webauthn', loginWebAuthn),
   router('/logout', logout),
 
+  router('/me', me),
   router('/health', health),
   router('/introspect', introspect),
 


### PR DESCRIPTION
The 'me' endpoint always redirects to the currently logged in principal.