### PR TITLE
Make docker image smaller.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,10 @@ COPY src src
 
 RUN npm i --environment=dev && npx tsc && npm prune --production && rm -r src/
 
+# Remove large files that are not needed in the final image
+# geoip databases we're not using are worth > 100MB
+RUN rm -r node_modules/geoip-lite/data/*city*
+
 # Stage 2: run!
 FROM node:20-alpine
 LABEL org.opencontainers.image.source https://github.com/curveball/a12n-server

--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,7 @@ Changelog
   EFF wordlist and generate diceware passwords ourselves.
 * Docker image could not be built on arm64 due to a transative dependency using
   an old version of libsodium.
+* Reduced docker image from 366MB to 216MB with no loss of functionality.
 
 
 0.29.0 (2025-02-07)


### PR DESCRIPTION
Reduces the docker image from 366MB to 216MB

Would be nice to reduce this even further by using the 'slim' node
image, but that seems a bit harder to do right now.
