### PR TITLE
Emit a more specific error for 'too many failed login attempts'.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,9 @@ Changelog
 * Docker image could not be built on arm64 due to a transative dependency using
   an old version of libsodium.
 * Reduced docker image from 366MB to 216MB with no loss of functionality.
+* This small refactoring allows us to emit `too_many_failed_login_attempts`
+  from the `authorization_challenge` system. Before, it emitted
+  `invalid_username_or_password` which is confusing.
 
 
 0.29.0 (2025-02-07)

--- a/src/login/error.ts
+++ b/src/login/error.ts
@@ -25,7 +25,9 @@ type ChallengeErrorCode =
   // The email address used to log in was not verified.
   | 'email_not_verified'
   // Email verification expired and the user must enter a OTP to continue
-  | 'email_verification_code_invalid';
+  | 'email_verification_code_invalid'
+  // User tried to log in with an incorrect password one too many times.
+  | 'too_many_failed_login_attempts';
 
 type ExtraParams = {
   censored_email?: string;
@@ -68,3 +70,10 @@ export class A12nLoginChallengeError extends OAuth2Error {
   }
 
 }
+
+/**
+ * Errors thrown from validateUserCredentials.
+ */
+export class TooManyLoginAttemptsError extends Error {}
+export class IncorrectPassword extends Error {}
+

--- a/src/user/error.ts
+++ b/src/user/error.ts
@@ -1,0 +1,5 @@
+/**
+ * Errors thrown from validateUserCredentials.
+ */
+export class TooManyLoginAttemptsError extends Error {}
+export class IncorrectPassword extends Error {}

--- a/src/user/service.ts
+++ b/src/user/service.ts
@@ -89,7 +89,7 @@ export async function validateUserCredentials(user: User, password: string, log:
   if (await loginActivityService.isAccountLocked(user)) {
     await loginActivityService.incrementFailedLoginAttempts(user);
     await log('login-failed-account-locked');
-    throw new TooManyLoginAttemptsError(TOO_MANY_FAILED_ATTEMPTS)
+    throw new TooManyLoginAttemptsError(TOO_MANY_FAILED_ATTEMPTS);
   }
 
   if (!await validatePassword(user, password)) {
@@ -97,7 +97,7 @@ export async function validateUserCredentials(user: User, password: string, log:
 
     if (loginActivityService.reachedMaxAttempts(incrementedAttempts)) {
       await log('account-locked');
-      throw new TooManyLoginAttemptsError(TOO_MANY_FAILED_ATTEMPTS)
+      throw new TooManyLoginAttemptsError(TOO_MANY_FAILED_ATTEMPTS);
     }
 
     await log('password-check-failed');


### PR DESCRIPTION
This small refactoring allows us to emit
`too_many_failed_login_attempts` from the `authorization_challenge`
system. Before, it emitted `invalid_username_or_password` which is
confusing.
