### PR TITLE
always percent-decode both basic auth components for OAuth2.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,8 @@ Changelog
 
 * If an app has 'uri' set during creation, it's now returned as a me link
   relationship from the app endpoint.
+* Basic-auth headers for OAuth2 token requests are percent-decoded. This was
+  always required for OAuth2, but I missed this at the time.
 
 
 0.30.0 (2025-03-17)

--- a/src/app-client/parse-basic-auth.ts
+++ b/src/app-client/parse-basic-auth.ts
@@ -17,6 +17,9 @@ export default function parseBasic(ctx: Context): null | [string, string] {
     return null;
   }
 
-  return [decodedMatch[1], decodedMatch[2]] as [string, string];
+  return [
+    decodeURIComponent(decodedMatch[1]),
+    decodeURIComponent(decodedMatch[2])
+  ];
 
 }

--- a/src/app-client/service.ts
+++ b/src/app-client/service.ts
@@ -100,8 +100,6 @@ export async function getAppClientFromBasicAuth(ctx: Context): Promise<AppClient
       throw e;
     }
   }
-  // Some broken clients urlencode ":" so this is a workaround.
-  basicAuth[1] = basicAuth[1].replace(/%3A/ig, ':');
 
   if (!await validateSecret(oauth2Client, basicAuth[1])) {
     throw new Unauthorized('Client id or secret incorrect', 'Basic');


### PR DESCRIPTION
This is a requirement for OAuth2, which I had missed at the time.
