### PR TITLE
doc: adds status badges for pipelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,14 @@
 `@curveball/a12n-server`: A simple authentication server
 ==================
+<span style="display: flex; justify-content: start; padding: 0 0.5rem;">
+
+[![Docker](https://github.com/curveball/a12n-server/actions/workflows/docker-publish.yml/badge.svg)](https://github.com/curveball/a12n-server/actions/workflows/docker-publish.yml)
+
+[![Publish NPM package](https://github.com/curveball/a12n-server/actions/workflows/npm-publish.yml/badge.svg)](https://github.com/curveball/a12n-server/actions/workflows/npm-publish.yml)
+
+[![Test](https://github.com/curveball/a12n-server/actions/workflows/test.yml/badge.svg)](https://github.com/curveball/a12n-server/actions/workflows/test.yml)
+
+</span>
 
 *a12n* is short for "authentication".
 


### PR DESCRIPTION
This pull request updates the `README.md` file to enhance its presentation and provide quick access to project-related workflows. 

Documentation enhancements:

* Added badges for Docker publishing, NPM package publishing, and test workflows to the `README.md` file. These badges link to their respective GitHub Actions workflows, offering better visibility into the project's CI/CD status.