### PR TITLE
Refactor verification into a new service.

### DIFF
--- a/src/principal-identity/service.ts
+++ b/src/principal-identity/service.ts
@@ -3,10 +3,8 @@ import knex, { insertAndGetId } from '../database.ts';
 import { PrincipalIdentitiesRecord } from 'knex/types/tables.ts';
 import { NotFound, MethodNotAllowed, BadRequest } from '@curveball/http-errors';
 import { generatePublicId } from '../crypto.ts';
-import { sendTemplatedMail } from '../mailer/service.ts';
 import * as services from '../services.ts';
-import { generateVerificationDigits } from '../crypto.ts';
-import { sendVerificationCode } from '../sms/service.ts';
+import * as uriVerification from '../uri-verification/service.ts';
 
 export async function findByPrincipal(principal: Principal): Promise<PrincipalIdentity[]> {
 
@@ -141,37 +139,10 @@ export async function sendVerificationRequest(identity: PrincipalIdentity, ip: s
     throw new MethodNotAllowed('Only mailto: and tel: identities can be verified currently. Make a feature request if you want to support other kinds of identities');
   }
 
-  const uri = new URL(identity.uri);
-
-  switch(uri.protocol) {
-    case 'mailto:':
-      await sendTemplatedMail({
-        templateName: 'emails/verify-email',
-        to: uri.pathname,
-        subject: 'Verify your email',
-      }, {
-        code: await getCodeForIdentity(identity),
-        expireMinutes: CODE_LIFETIME_MINUTES,
-        name: identity.principal.nickname,
-        date: new Date().toISOString(),
-        ip,
-      });
-      break;
-
-    case 'tel:':
-      await sendVerificationCode(
-        uri.pathname,
-        await getCodeForIdentity(identity),
-      );
-      break;
-    default:
-      throw new MethodNotAllowed('Only mailto: and tel: identities can be verified currently. Make a feature request if you want to support other kinds of identities');
-
-  }
-
-
+  await uriVerification.sendVerificationRequest(identity.uri, ip, identity.principal.nickname);
 
 }
+
 export async function sendOtpRequest(identity: PrincipalIdentity, ip: string): Promise<void> {
 
   if (!identity.uri.startsWith('mailto:')) {
@@ -181,54 +152,14 @@ export async function sendOtpRequest(identity: PrincipalIdentity, ip: string): P
     throw new MethodNotAllowed('This identity is not configured for mfa');
   }
 
-  await sendTemplatedMail({
-    templateName: 'emails/totp-email',
-    to: identity.uri.slice(7),
-    subject: 'Your login code',
-  }, {
-    code: await getCodeForIdentity(identity),
-    expireMinutes: CODE_LIFETIME_MINUTES,
-    name: identity.principal.nickname,
-    date: new Date().toISOString(),
-    ip,
-  });
+  await uriVerification.sendOtpRequest(identity.uri, ip, identity.principal.nickname);
 
 }
-
-const identityNS = 'a12n:identity-verification:';
 
 export async function verifyIdentity(identity: PrincipalIdentity, code: string): Promise<void> {
 
-  const storedCode = await services.kv.get(identityNS + identity.externalId);
-  // Delete code after, whether it was correct or not.
-  await services.kv.del(identityNS + identity.externalId);
-
-  if (storedCode === null) {
-    throw new BadRequest('Verification code incorrect or expired. Try restarting the verification process');
-  } else if (storedCode !== code) {
-    throw new BadRequest('Verification code incorrect');
-  }
-
+  await uriVerification.verifyCode(identity.uri, code);
   await markVerified(identity);
-
-}
-
-const CODE_LIFETIME_MINUTES = 30;
-
-/**
- * Generates a secret code for an identity that may be used to validate ownership later.
- *
- * An identity will only have 1 active code.
- */
-async function getCodeForIdentity(identity: PrincipalIdentity): Promise<string> {
-
-  const code = generateVerificationDigits();
-  await services.kv.set(
-    identityNS + identity.externalId,
-    code,
-    { ttl: CODE_LIFETIME_MINUTES * 60000 }
-  );
-  return code;
 
 }
 

--- a/src/uri-verification/service.ts
+++ b/src/uri-verification/service.ts
@@ -45,7 +45,7 @@ export async function sendVerificationRequest(uri: string, ip: string, name?: st
  */
 export async function sendOtpRequest(uri: string, ip: string, name?: string): Promise<void> {
   const validatedUri = validateVerificationUri(uri);
-  
+
   if (!validatedUri.startsWith('mailto:')) {
     throw new MethodNotAllowed('Only email URIs are supported for OTP currently. Make a feature request if you want to support other kinds of URIs');
   }
@@ -69,7 +69,7 @@ export async function sendOtpRequest(uri: string, ip: string, name?: string): Pr
  */
 export async function verifyCode(uri: string, code: string): Promise<boolean> {
   const validatedUri = validateVerificationUri(uri);
-  
+
   const storedCode = await kv.get<string>(verificationNS + validatedUri);
   // Delete code after, whether it was correct or not.
   await kv.del(verificationNS + validatedUri);
@@ -103,7 +103,7 @@ async function getCodeForUri(uri: string): Promise<string> {
  */
 function validateVerificationUri(uri: string): string {
   const uriObj = new URL(uri);
-  
+
   switch(uriObj.protocol) {
     case 'mailto:':
       if (/^[^@]+@[^@]+\.[^@]+$/.test(uriObj.pathname)) {
@@ -120,4 +120,4 @@ function validateVerificationUri(uri: string): string {
     default:
       throw new BadRequest('Invalid verification URI. Only mailto and tel URIs are supported for verification at the moment, but we want to support your use-case! Let us know');
   }
-} 
+}

--- a/src/uri-verification/service.ts
+++ b/src/uri-verification/service.ts
@@ -1,0 +1,123 @@
+import { MethodNotAllowed, BadRequest } from '@curveball/http-errors';
+import { generateVerificationDigits } from '../crypto.ts';
+import { sendTemplatedMail } from '../mailer/service.ts';
+import { sendVerificationCode } from '../sms/service.ts';
+import * as kv from '../kv/service.ts';
+
+const CODE_LIFETIME_MINUTES = 30;
+const verificationNS = 'a12n:uri-verification:';
+
+/**
+ * Sends a verification code to the specified URI (email or phone)
+ */
+export async function sendVerificationRequest(uri: string, ip: string, name?: string): Promise<void> {
+  const validatedUri = validateVerificationUri(uri);
+  const uriObj = new URL(validatedUri);
+
+  switch(uriObj.protocol) {
+    case 'mailto:':
+      await sendTemplatedMail({
+        templateName: 'emails/verify-email',
+        to: uriObj.pathname,
+        subject: 'Verify your email',
+      }, {
+        code: await getCodeForUri(validatedUri),
+        expireMinutes: CODE_LIFETIME_MINUTES,
+        name: name || 'there',
+        date: new Date().toISOString(),
+        ip,
+      });
+      break;
+
+    case 'tel:':
+      await sendVerificationCode(
+        uriObj.pathname,
+        await getCodeForUri(validatedUri),
+      );
+      break;
+    default:
+      throw new MethodNotAllowed('Only mailto: and tel: URIs can be verified currently. Make a feature request if you want to support other kinds of URIs');
+  }
+}
+
+/**
+ * Sends an OTP code to the specified email URI
+ */
+export async function sendOtpRequest(uri: string, ip: string, name?: string): Promise<void> {
+  const validatedUri = validateVerificationUri(uri);
+  
+  if (!validatedUri.startsWith('mailto:')) {
+    throw new MethodNotAllowed('Only email URIs are supported for OTP currently. Make a feature request if you want to support other kinds of URIs');
+  }
+
+  const uriObj = new URL(validatedUri);
+  await sendTemplatedMail({
+    templateName: 'emails/totp-email',
+    to: uriObj.pathname,
+    subject: 'Your login code',
+  }, {
+    code: await getCodeForUri(validatedUri),
+    expireMinutes: CODE_LIFETIME_MINUTES,
+    name: name || 'there',
+    date: new Date().toISOString(),
+    ip,
+  });
+}
+
+/**
+ * Verifies a code for the specified URI
+ */
+export async function verifyCode(uri: string, code: string): Promise<boolean> {
+  const validatedUri = validateVerificationUri(uri);
+  
+  const storedCode = await kv.get<string>(verificationNS + validatedUri);
+  // Delete code after, whether it was correct or not.
+  await kv.del(verificationNS + validatedUri);
+
+  if (storedCode === null) {
+    throw new BadRequest('Verification code incorrect or expired. Try restarting the verification process');
+  } else if (storedCode !== code) {
+    throw new BadRequest('Verification code incorrect');
+  }
+
+  return true;
+}
+
+/**
+ * Generates a secret code for a URI that may be used to validate ownership later.
+ *
+ * A URI will only have 1 active code.
+ */
+async function getCodeForUri(uri: string): Promise<string> {
+  const code = generateVerificationDigits();
+  await kv.set(
+    verificationNS + uri,
+    code,
+    { ttl: CODE_LIFETIME_MINUTES * 60000 }
+  );
+  return code;
+}
+
+/**
+ * Helper function to validate verification URI formats
+ */
+function validateVerificationUri(uri: string): string {
+  const uriObj = new URL(uri);
+  
+  switch(uriObj.protocol) {
+    case 'mailto:':
+      if (/^[^@]+@[^@]+\.[^@]+$/.test(uriObj.pathname)) {
+        return uriObj.toString();
+      } else {
+        throw new BadRequest('Invalid email address');
+      }
+    case 'tel:':
+      if (/^\+?[0-9]+$/.test(uriObj.pathname)) {
+        return uriObj.toString();
+      } else {
+        throw new BadRequest('Invalid phone number. We only currently support international phone numbers in the format tel:+[0-9]+, without spaces or other characters.');
+      }
+    default:
+      throw new BadRequest('Invalid verification URI. Only mailto and tel URIs are supported for verification at the moment, but we want to support your use-case! Let us know');
+  }
+} 


### PR DESCRIPTION
The first commit is 100% written by cursor, using the following prompt:

> This is a refactor job.
>
> Create a new 'verification service' that can verify email and phone numbers. This functionality should be refactored from principal-identity/service.ts into a new uri-verification/service.ts file.
>
> The difference is that this new service should not operate on the PrincipalIdentity type, but instead simply take a mailto/href uri for all functions. Both when sending the request, and when validating the request.

Any commits after the is me manually fixing/intervening with vim but I thought it
may be interesting to see the process.
