### PR TITLE
fix: export missing types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,5 +5,6 @@
  */
 export { default as mainMw } from './main-mw.ts';
 export { load as init } from './server-settings.ts';
-
 import './db-types.ts';
+import './types.ts';
+


### PR DESCRIPTION
The purpose of this PR is to export types from `src/types.ts`. 

Context:

I found that I wanted to import `ServerStats` and `UserInfo` from here in order to maintain a contract with the data being presented from API responses on `a12n-server-admin`, however I found I was unable to import these types.

