### PR TITLE
ci: prevent single test failure in matrix from blocking execution of other tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,9 @@ jobs:
       matrix:
         node-version: ['18.x', '20.x', '22.x']
         db-driver: ['mysql', 'postgres', 'sqlite3']
+      fail-fast: false
     needs: build
+    
     services:
       mysql:
         image: mysql


### PR DESCRIPTION
When #687 was merged, it appears a ` generatePassword()` test flaked and blocked all subsequent tests from executing. https://github.com/curveball/a12n-server/actions/runs/16815869417/attempts/1 

I subsquently had to re-run/click the other 9 😆 

This change prevents 1 single test failure from blocking execution of other tests